### PR TITLE
Fix start value variable typo in graph traversal algorithms

### DIFF
--- a/AlgorithmLibrary/BFS.js
+++ b/AlgorithmLibrary/BFS.js
@@ -109,20 +109,20 @@ BFS.prototype.setup = function()
 
 BFS.prototype.startCallback = function(event)
 {
-	var startValue;
-	
-	if (this.startField.value != "")
-	{
-		startvalue = this.startField.value;
-		this.startField.value = "";
-		if (parseInt(startvalue) < this.size)
-			this.implementAction(this.doBFS.bind(this),startvalue);
-	}
+        var startValue;
+
+        if (this.startField.value != "")
+        {
+                startValue = this.startField.value;
+                this.startField.value = "";
+                if (parseInt(startValue) < this.size)
+                        this.implementAction(this.doBFS.bind(this), startValue);
+        }
 }
 
 
 
-BFS.prototype.doBFS = function(startVetex)
+BFS.prototype.doBFS = function(startVertex)
 {
 	this.visited = new Array(this.size);
 	this.commands = new Array();
@@ -150,7 +150,7 @@ BFS.prototype.doBFS = function(startVetex)
 		queueID[i] = this.nextIndex++;
 		
 	}
-	var vertex = parseInt(startVetex);
+        var vertex = parseInt(startVertex);
 	this.visited[vertex] = true;
 	this.queue[tail] = vertex;			
 	this.cmd("CreateLabel", queueID[tail],  vertex, QUEUE_START_X + queueSize * QUEUE_SPACING, QUEUE_START_Y);

--- a/AlgorithmLibrary/DFS.js
+++ b/AlgorithmLibrary/DFS.js
@@ -107,20 +107,20 @@ DFS.prototype.setup = function()
 
 DFS.prototype.startCallback = function(event)
 {
-	var startValue;
-	
-	if (this.startField.value != "")
-	{
-		startvalue = this.startField.value;
-		this.startField.value = "";
-		if (parseInt(startvalue) < this.size)
-			this.implementAction(this.doDFS.bind(this),startvalue);
-	}
+        var startValue;
+
+        if (this.startField.value != "")
+        {
+                startValue = this.startField.value;
+                this.startField.value = "";
+                if (parseInt(startValue) < this.size)
+                        this.implementAction(this.doDFS.bind(this), startValue);
+        }
 }
 
 
 
-DFS.prototype.doDFS = function(startVetex)
+DFS.prototype.doDFS = function(startVertex)
 {
 	this.visited = new Array(this.size);
 	this.commands = new Array();
@@ -139,7 +139,7 @@ DFS.prototype.doDFS = function(startVetex)
 		this.cmd("SetText", this.parentID[i], "");
 		this.visited[i] = false;
 	}
-	var vertex = parseInt(startVetex);
+        var vertex = parseInt(startVertex);
 	this.cmd("CreateHighlightCircle", this.highlightCircleL, HIGHLIGHT_CIRCLE_COLOR, this.x_pos_logical[vertex], this.y_pos_logical[vertex]);
 	this.cmd("SetLayer", this.highlightCircleL, 1);
 	this.cmd("CreateHighlightCircle", this.highlightCircleAL, HIGHLIGHT_CIRCLE_COLOR,this.adj_list_x_start - this.adj_list_width, this.adj_list_y_start + vertex*this.adj_list_height);

--- a/AlgorithmLibrary/DijkstraPrim.js
+++ b/AlgorithmLibrary/DijkstraPrim.js
@@ -393,15 +393,15 @@ DijkstraPrim.prototype.reset = function()
 
 DijkstraPrim.prototype.startCallback = function(event)
 {
-	var startValue;
-	
-	if (this.startField.value != "")
-	{
-		startvalue = this.startField.value;
-		this.startField.value = "";
-		if (parseInt(startvalue) < this.size)
-			this.implementAction(this.doDijkstraPrim.bind(this),startvalue);
-	}
+        var startValue;
+
+        if (this.startField.value != "")
+        {
+                startValue = this.startField.value;
+                this.startField.value = "";
+                if (parseInt(startValue) < this.size)
+                        this.implementAction(this.doDijkstraPrim.bind(this), startValue);
+        }
 }
 
 


### PR DESCRIPTION
## Summary
- Correct start value handling in BFS, DFS, and Dijkstra/Prim algorithms to use local `startValue` variable
- Rename traversal helper parameters to `startVertex` for clarity

## Testing
- `node --check AlgorithmLibrary/BFS.js`
- `node --check AlgorithmLibrary/DFS.js`
- `node --check AlgorithmLibrary/DijkstraPrim.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6acc17834832ca238242becda5a4c