### PR TITLE
Draw colored ovals for Path Sum III paths

### DIFF
--- a/AlgorithmLibrary/PathSumIII.js
+++ b/AlgorithmLibrary/PathSumIII.js
@@ -34,8 +34,8 @@ PathSumIII.prototype.init = function(am, w, h) {
   this.sumLabelIDs = [];
   this.countLabelID = -1;
 
-  // highlight circles for successful paths
-  this.pathCircleIDs = [];
+  // loops for successful paths
+  this.pathOvalIDs = [];
   this.pathIdx = 0;
   this.pathColors = [
     "#FFD700", "#00BFFF", "#FF6347",
@@ -260,7 +260,7 @@ PathSumIII.prototype.reset = function() {
   this.codeIDs = [];
   this.sumLabelIDs = [];
   this.countLabelID = -1;
-  this.pathCircleIDs = [];
+  this.pathOvalIDs = [];
   this.pathIdx = 0;
 };
 
@@ -275,12 +275,11 @@ PathSumIII.prototype.findPaths = function() {
   this.commands = [];
   for (const id of this.sumLabelIDs) this.cmd("Delete", id);
   this.sumLabelIDs = [];
-  for (const id of this.pathCircleIDs) this.cmd("Delete", id);
-  this.pathCircleIDs = [];
+  for (const id of this.pathOvalIDs) this.cmd("Delete", id);
+  this.pathOvalIDs = [];
   this.pathIdx = 0;
   for (const id in this.nodeValue) {
     this.cmd("SetBackgroundColor", parseInt(id), "#FFF");
-    this.cmd("SetHighlight", parseInt(id), 0);
   }
   this.cmd("SetText", this.countLabelID, "Count: 0");
   let count = 0;
@@ -295,22 +294,26 @@ PathSumIII.prototype.findPaths = function() {
 
   const showPath = (nodes) => {
     const color = this.pathColors[this.pathIdx % this.pathColors.length];
-    const radius = 25 + this.pathIdx * 4;
-    // moving circle to trace the path
-    const moveID = this.nextIndex++;
-    this.cmd("CreateHighlightCircle", moveID, color, this.nodeX[nodes[0]], this.nodeY[nodes[0]], radius);
+
+    const xs = nodes.map((id) => this.nodeX[id]);
+    const ys = nodes.map((id) => this.nodeY[id]);
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
+    const centerX = (minX + maxX) / 2;
+    const centerY = (minY + maxY) / 2;
+    const width = Math.max(maxX - minX, 40) + 60;
+    const height = Math.max(maxY - minY, 40) + 60;
+
+    const loopID = this.nextIndex++;
+    this.cmd("CreateHighlightOval", loopID, color, centerX, centerY, 0, 0);
     this.cmd("Step");
-    for (let i = 1; i < nodes.length; i++) {
-      const nid = nodes[i];
-      this.cmd("Move", moveID, this.nodeX[nid], this.nodeY[nid]);
-      this.cmd("Step");
-    }
-    for (const id of nodes) {
-      const circleID = this.nextIndex++;
-      this.cmd("CreateHighlightCircle", circleID, color, this.nodeX[id], this.nodeY[id], radius);
-      this.pathCircleIDs.push(circleID);
-    }
-    this.cmd("Delete", moveID);
+    this.cmd("SetWidth", loopID, width);
+    this.cmd("Step");
+    this.cmd("SetHeight", loopID, height);
+    this.cmd("Step");
+    this.pathOvalIDs.push(loopID);
     this.pathIdx++;
   };
 
@@ -322,7 +325,6 @@ PathSumIII.prototype.findPaths = function() {
       return 0;
     }
     highlight(6);
-    this.cmd("SetHighlight", nodeID, 1);
     const val = this.nodeValue[nodeID];
     cur += val;
     path.push(nodeID);
@@ -357,7 +359,6 @@ PathSumIII.prototype.findPaths = function() {
     const label = this.sumLabelIDs.pop();
     this.cmd("Delete", label);
     path.pop();
-    this.cmd("SetHighlight", nodeID, 0);
     this.cmd("SetBackgroundColor", nodeID, "#FFF");
     this.cmd("Step");
     return 0;

--- a/AnimationLibrary/AnimationMain.js
+++ b/AnimationLibrary/AnimationMain.js
@@ -796,24 +796,39 @@ function AnimationManager(objectManager)
 					this.animatedObjects.removeObject(objectID);
 				}
 			}
-			else if (nextCommand[0].toUpperCase() == "CREATEHIGHLIGHTCIRCLE")
-			{
-				if (nextCommand.length > 5)
-				{
-					this.animatedObjects.addHighlightCircleObject(parseInt(nextCommand[1]), this.parseColor(nextCommand[2]), parseFloat(nextCommand[5]));
-				}
-				else
-				{
-					this.animatedObjects.addHighlightCircleObject(parseInt(nextCommand[1]), this.parseColor(nextCommand[2]), 20);						
-				}
-				if (nextCommand.length > 4)
-				{
-					this.animatedObjects.setNodePosition(parseInt(nextCommand[1]), parseInt(nextCommand[3]), parseInt(nextCommand[4]));
-				}
-				undoBlock.push(new UndoCreate(parseInt(nextCommand[1])));
-				
-				
-			}
+                        else if (nextCommand[0].toUpperCase() == "CREATEHIGHLIGHTOVAL")
+                        {
+                                var id = parseInt(nextCommand[1]);
+                                var color = this.parseColor(nextCommand[2]);
+                                var width = (nextCommand.length > 5) ? parseFloat(nextCommand[5]) : 40;
+                                var height = (nextCommand.length > 6) ? parseFloat(nextCommand[6]) : width;
+                                this.animatedObjects.addHighlightOvalObject(id, color, width, height);
+                                if (nextCommand.length > 4)
+                                {
+                                        this.animatedObjects.setNodePosition(id, parseInt(nextCommand[3]), parseInt(nextCommand[4]));
+                                }
+                                undoBlock.push(new UndoCreate(id));
+
+
+                        }
+                        else if (nextCommand[0].toUpperCase() == "CREATEHIGHLIGHTCIRCLE")
+                        {
+                                if (nextCommand.length > 5)
+                                {
+                                        this.animatedObjects.addHighlightCircleObject(parseInt(nextCommand[1]), this.parseColor(nextCommand[2]), parseFloat(nextCommand[5]));
+                                }
+                                else
+                                {
+                                        this.animatedObjects.addHighlightCircleObject(parseInt(nextCommand[1]), this.parseColor(nextCommand[2]), 20);
+                                }
+                                if (nextCommand.length > 4)
+                                {
+                                        this.animatedObjects.setNodePosition(parseInt(nextCommand[1]), parseInt(nextCommand[3]), parseInt(nextCommand[4]));
+                                }
+                                undoBlock.push(new UndoCreate(parseInt(nextCommand[1])));
+
+
+                        }
 			else if (nextCommand[0].toUpperCase() == "CREATELABEL")
 			{
 				if (nextCommand.length == 6)

--- a/AnimationLibrary/HighlightOval.js
+++ b/AnimationLibrary/HighlightOval.js
@@ -1,0 +1,102 @@
+// Copyright 2011 David Galles, University of San Francisco. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+// conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+// of conditions and the following disclaimer in the documentation and/or other materials
+// provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// The views and conclusions contained in the software and documentation are those of the
+// authors and should not be interpreted as representing official policies, either expressed
+// or implied, of the University of San Francisco
+
+// "Class" HighlightOval
+
+var HighlightOval = function(objectID, color, width, height)
+{
+        this.objectID = objectID;
+        this.w = width;
+        this.h = height;
+        this.thickness = 4;
+        this.foregroundColor = color;
+        this.x = 0;
+        this.y = 0;
+        this.alpha = 1;
+}
+
+HighlightOval.prototype = new AnimatedObject();
+HighlightOval.prototype.constructor = HighlightOval;
+
+HighlightOval.prototype.setWidth = function(w)
+{
+        this.w = w;
+}
+
+HighlightOval.prototype.setHeight = function(h)
+{
+        this.h = h;
+}
+
+HighlightOval.prototype.getWidth = function()
+{
+        return this.w;
+}
+
+HighlightOval.prototype.getHeight = function()
+{
+        return this.h;
+}
+
+HighlightOval.prototype.draw = function(ctx)
+{
+        ctx.globalAlpha = this.alpha;
+        ctx.strokeStyle = this.foregroundColor;
+        ctx.lineWidth = this.thickness;
+        ctx.beginPath();
+        ctx.ellipse(this.x, this.y, this.w/2, this.h/2, 0, 0, Math.PI*2, true);
+        ctx.closePath();
+        ctx.stroke();
+}
+
+HighlightOval.prototype.createUndoDelete = function()
+{
+        return new UndoDeleteHighlightOval(this.objectID, this.x, this.y, this.foregroundColor, this.w, this.h, this.layer, this.alpha);
+}
+
+function UndoDeleteHighlightOval(objectID, x, y, color, w, h, layer, alpha)
+{
+        this.objectID = objectID;
+        this.x = x;
+        this.y = y;
+        this.color = color;
+        this.w = w;
+        this.h = h;
+        this.layer = layer;
+        this.alpha = alpha;
+}
+
+UndoDeleteHighlightOval.prototype = new UndoBlock();
+UndoDeleteHighlightOval.prototype.constructor = UndoDeleteHighlightOval;
+
+UndoDeleteHighlightOval.prototype.undoInitialStep = function(world)
+{
+        world.addHighlightOvalObject(this.objectID, this.color, this.w, this.h);
+        world.setLayer(this.objectID, this.layer);
+        world.setNodePosition(this.objectID, this.x, this.y);
+        world.setAlpha(this.objectID, this.alpha);
+}
+

--- a/AnimationLibrary/ObjectManager.js
+++ b/AnimationLibrary/ObjectManager.js
@@ -131,19 +131,29 @@ function ObjectManager()
 	}
 
 	
-	this.addHighlightCircleObject = function(objectID, objectColor, radius)
-	{
-		if (this.Nodes[objectID] != null && this.Nodes[objectID] != undefined)
-		{
-  	            throw "addHighlightCircleObject:Object with same ID (" + String(objectID) + ") already Exists!"
-		}
-		var newNode = new HighlightCircle(objectID, objectColor, radius)
-		this.Nodes[objectID] = newNode;		
-	}
-	
-	this.setEdgeAlpha = function(fromID, toID, alphaVal)
-	{
-		var oldAlpha = 1.0; 
+        this.addHighlightCircleObject = function(objectID, objectColor, radius)
+        {
+                if (this.Nodes[objectID] != null && this.Nodes[objectID] != undefined)
+                {
+                    throw "addHighlightCircleObject:Object with same ID (" + String(objectID) + ") already Exists!"
+                }
+                var newNode = new HighlightCircle(objectID, objectColor, radius)
+                this.Nodes[objectID] = newNode;
+        }
+
+        this.addHighlightOvalObject = function(objectID, objectColor, width, height)
+        {
+                if (this.Nodes[objectID] != null && this.Nodes[objectID] != undefined)
+                {
+                    throw "addHighlightOvalObject:Object with same ID (" + String(objectID) + ") already Exists!"
+                }
+                var newNode = new HighlightOval(objectID, objectColor, width, height)
+                this.Nodes[objectID] = newNode;
+        }
+
+        this.setEdgeAlpha = function(fromID, toID, alphaVal)
+        {
+                var oldAlpha = 1.0;
 		if (this.Edges[fromID] != null &&
 			this.Edges[fromID] != undefined)
 		{

--- a/PathSumIII.html
+++ b/PathSumIII.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Path Sum III (LeetCode 437)</title>
+    <title>Path Sum III (LeetCode 437) - Loop Highlight</title>
     <link rel="stylesheet" href="visualizationPageStyle.css" />
     <link rel="stylesheet" href="ThirdParty/jquery-ui-1.8.11.custom.css" />
     <script src="ThirdParty/jquery-1.5.2.min.js"></script>
@@ -15,6 +15,7 @@
     <script type="text/javascript" src="AnimationLibrary/AnimatedRectangle.js"></script>
     <script type="text/javascript" src="AnimationLibrary/AnimatedLinkedList.js"></script>
     <script type="text/javascript" src="AnimationLibrary/HighlightCircle.js"></script>
+    <script type="text/javascript" src="AnimationLibrary/HighlightOval.js"></script>
     <script type="text/javascript" src="AnimationLibrary/Line.js"></script>
     <script type="text/javascript" src="AnimationLibrary/ObjectManager.js"></script>
     <script type="text/javascript" src="AnimationLibrary/AnimationMain.js"></script>
@@ -24,7 +25,7 @@
   <body onload="init();" class="VisualizationMainPage">
     <div id="container">
       <div id="header">
-        <h1 id="title" style="font-size:24px;font-weight:bold;">Path Sum III (LeetCode 437)</h1>
+        <h1 id="title" style="font-size:24px;font-weight:bold;">Path Sum III (LeetCode 437) - Loop Highlight</h1>
       </div>
       <div id="mainContent">
         <div id="algoControlSection">


### PR DESCRIPTION
## Summary
- animate discovery by drawing an expanding oval around each valid path
- add reusable HighlightOval shape plus command support in animation engine
- load new HighlightOval script on Path Sum III page

## Testing
- `node --check AnimationLibrary/HighlightOval.js`
- `node --check AlgorithmLibrary/PathSumIII.js`
- `node --check AnimationLibrary/ObjectManager.js`
- `node --check AnimationLibrary/AnimationMain.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd3c4878f0832c8c3a88ec11900b34