### PR TITLE
Add ellipse highlighting for Path Sum III visualization

### DIFF
--- a/AnimationLibrary/AnimationMain.js
+++ b/AnimationLibrary/AnimationMain.js
@@ -814,8 +814,22 @@ function AnimationManager(objectManager)
 
 
                         }
-			else if (nextCommand[0].toUpperCase() == "CREATELABEL")
-			{
+                        else if (nextCommand[0].toUpperCase() == "CREATEHIGHLIGHTOVAL")
+                        {
+                                this.animatedObjects.addHighlightOvalObject(
+                                        parseInt(nextCommand[1]),
+                                        this.parseColor(nextCommand[2]),
+                                        parseFloat(nextCommand[5]),
+                                        parseFloat(nextCommand[6]),
+                                        nextCommand.length > 7 ? parseFloat(nextCommand[7]) : 0
+                                );
+                                this.animatedObjects.setNodePosition(parseInt(nextCommand[1]), parseInt(nextCommand[3]), parseInt(nextCommand[4]));
+                                undoBlock.push(new UndoCreate(parseInt(nextCommand[1])));
+
+
+                        }
+                        else if (nextCommand[0].toUpperCase() == "CREATELABEL")
+                        {
 				if (nextCommand.length == 6)
 				{
 					this.animatedObjects.addLabelObject(parseInt(nextCommand[1]), nextCommand[2], this.parseBool(nextCommand[5]));						

--- a/AnimationLibrary/HighlightOval.js
+++ b/AnimationLibrary/HighlightOval.js
@@ -36,6 +36,7 @@ var HighlightOval = function(objectID, color, width, height)
         this.x = 0;
         this.y = 0;
         this.alpha = 1;
+        this.angle = 0;
 }
 
 HighlightOval.prototype = new AnimatedObject();
@@ -49,6 +50,11 @@ HighlightOval.prototype.setWidth = function(w)
 HighlightOval.prototype.setHeight = function(h)
 {
         this.h = h;
+}
+
+HighlightOval.prototype.setAngle = function(a)
+{
+        this.angle = a;
 }
 
 HighlightOval.prototype.getWidth = function()
@@ -67,17 +73,17 @@ HighlightOval.prototype.draw = function(ctx)
         ctx.strokeStyle = this.foregroundColor;
         ctx.lineWidth = this.thickness;
         ctx.beginPath();
-        ctx.ellipse(this.x, this.y, this.w/2, this.h/2, 0, 0, Math.PI*2, true);
+        ctx.ellipse(this.x, this.y, this.w/2, this.h/2, this.angle, 0, Math.PI*2, true);
         ctx.closePath();
         ctx.stroke();
 }
 
 HighlightOval.prototype.createUndoDelete = function()
 {
-        return new UndoDeleteHighlightOval(this.objectID, this.x, this.y, this.foregroundColor, this.w, this.h, this.layer, this.alpha);
+        return new UndoDeleteHighlightOval(this.objectID, this.x, this.y, this.foregroundColor, this.w, this.h, this.angle, this.layer, this.alpha);
 }
 
-function UndoDeleteHighlightOval(objectID, x, y, color, w, h, layer, alpha)
+function UndoDeleteHighlightOval(objectID, x, y, color, w, h, angle, layer, alpha)
 {
         this.objectID = objectID;
         this.x = x;
@@ -85,6 +91,7 @@ function UndoDeleteHighlightOval(objectID, x, y, color, w, h, layer, alpha)
         this.color = color;
         this.w = w;
         this.h = h;
+        this.angle = angle;
         this.layer = layer;
         this.alpha = alpha;
 }
@@ -94,7 +101,7 @@ UndoDeleteHighlightOval.prototype.constructor = UndoDeleteHighlightOval;
 
 UndoDeleteHighlightOval.prototype.undoInitialStep = function(world)
 {
-        world.addHighlightOvalObject(this.objectID, this.color, this.w, this.h);
+        world.addHighlightOvalObject(this.objectID, this.color, this.w, this.h, this.angle);
         world.setLayer(this.objectID, this.layer);
         world.setNodePosition(this.objectID, this.x, this.y);
         world.setAlpha(this.objectID, this.alpha);

--- a/AnimationLibrary/ObjectManager.js
+++ b/AnimationLibrary/ObjectManager.js
@@ -141,6 +141,20 @@ function ObjectManager()
                 this.Nodes[objectID] = newNode;
         }
 
+        this.addHighlightOvalObject = function(objectID, objectColor, width, height, angle)
+        {
+                if (this.Nodes[objectID] != null && this.Nodes[objectID] != undefined)
+                {
+                    throw "addHighlightOvalObject:Object with same ID (" + String(objectID) + ") already Exists!"
+                }
+                var newNode = new HighlightOval(objectID, objectColor, width, height)
+                if (angle != undefined)
+                {
+                        newNode.setAngle(angle);
+                }
+                this.Nodes[objectID] = newNode;
+        }
+
 
         this.setEdgeAlpha = function(fromID, toID, alphaVal)
         {

--- a/PathSumIII.html
+++ b/PathSumIII.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Path Sum III (LeetCode 437) - Loop Highlight</title>
+    <title>Path Sum III (LeetCode 437) - Ellipse Highlight</title>
     <link rel="stylesheet" href="visualizationPageStyle.css" />
     <link rel="stylesheet" href="ThirdParty/jquery-ui-1.8.11.custom.css" />
     <script src="ThirdParty/jquery-1.5.2.min.js"></script>
@@ -25,7 +25,7 @@
   <body onload="init();" class="VisualizationMainPage">
     <div id="container">
       <div id="header">
-        <h1 id="title" style="font-size:24px;font-weight:bold;">Path Sum III (LeetCode 437) - Loop Highlight</h1>
+        <h1 id="title" style="font-size:24px;font-weight:bold;">Path Sum III (LeetCode 437) - Ellipse Highlight</h1>
       </div>
       <div id="mainContent">
         <div id="algoControlSection">


### PR DESCRIPTION
## Summary
- Replace pen-drawn loops with rotated highlight ovals surrounding each qualifying Path Sum III sequence
- Track traversal with a red highlight circle
- Update UI text to reflect ellipse-based visualization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd76dbdff4832cb8245ab8b4b456df