### PR TITLE
Use stars and colored lines for Path Sum III visualization

### DIFF
--- a/PathSumIII.html
+++ b/PathSumIII.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Path Sum III (LeetCode 437) - Ellipse Highlight</title>
+    <title>Path Sum III (LeetCode 437) - Star Path Highlight</title>
     <link rel="stylesheet" href="visualizationPageStyle.css" />
     <link rel="stylesheet" href="ThirdParty/jquery-ui-1.8.11.custom.css" />
     <script src="ThirdParty/jquery-1.5.2.min.js"></script>
@@ -15,7 +15,6 @@
     <script type="text/javascript" src="AnimationLibrary/AnimatedRectangle.js"></script>
     <script type="text/javascript" src="AnimationLibrary/AnimatedLinkedList.js"></script>
     <script type="text/javascript" src="AnimationLibrary/HighlightCircle.js"></script>
-    <script type="text/javascript" src="AnimationLibrary/HighlightOval.js"></script>
     <script type="text/javascript" src="AnimationLibrary/Line.js"></script>
     <script type="text/javascript" src="AnimationLibrary/ObjectManager.js"></script>
     <script type="text/javascript" src="AnimationLibrary/AnimationMain.js"></script>
@@ -25,7 +24,7 @@
   <body onload="init();" class="VisualizationMainPage">
     <div id="container">
       <div id="header">
-        <h1 id="title" style="font-size:24px;font-weight:bold;">Path Sum III (LeetCode 437) - Ellipse Highlight</h1>
+        <h1 id="title" style="font-size:24px;font-weight:bold;">Path Sum III (LeetCode 437) - Star Path Highlight</h1>
       </div>
       <div id="mainContent">
         <div id="algoControlSection">


### PR DESCRIPTION
## Summary
- Replace highlight ovals with stars connected by lines for found paths
- Remove unused HighlightOval script and update page title to reflect new effect

## Testing
- `node --check AlgorithmLibrary/PathSumIII.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd8725e910832c88568a3b3c79d290