### PR TITLE
Use stars and curved lines for Path Sum III visualization

### DIFF
--- a/AlgorithmLibrary/PathSumIII.js
+++ b/AlgorithmLibrary/PathSumIII.js
@@ -5,7 +5,7 @@
  * - Build tree from level-order input
  * - DFS with prefix sums to count paths equal to target
  * - Control buttons: Build Tree, Find Paths, Prev/Next/Stop/Resume
- * - Each qualifying path is highlighted with a unique colored loop
+ * - Each qualifying path is highlighted with colored stars and lines
  */
 
 function PathSumIII(am, w, h) { this.init(am, w, h); }
@@ -33,17 +33,35 @@ PathSumIII.prototype.init = function(am, w, h) {
   this.codeIDs = [];
   this.sumLabelIDs = [];
   this.countLabelID = -1;
-  // highlight ovals for successful paths
-  this.pathLoopIDs = [];
+  // IDs for star markers and connecting lines for successful paths
+  this.pathHighlightIDs = [];
   this.pathIdx = 0;
-  this.pathColors = [
-    "#00BFFF", "#FF0000", "#32CD32",
-    "#FFA500", "#EE82EE", "#FFD700", "#8A2BE2"
-  ];
-
+  // Track how many stars have been placed at each node to offset them uniquely
+  this.starCounts = {};
   // 540x960 canvas sections
   this.sectionDivY1 = 360;
   this.sectionDivY2 = 660;
+};
+
+// Generate a unique star symbol and matching color for each discovered path
+PathSumIII.prototype.nextPathStyle = function() {
+  const hue = (this.pathIdx * 137) % 360; // use golden angle for spacing
+  const starShapes = [
+    "★",
+    "✦",
+    "✶",
+    "✹",
+    "✸",
+    "✺",
+    "✻",
+    "✼",
+    "✽",
+    "✾",
+    "✿"
+  ];
+  const star = starShapes[this.pathIdx % starShapes.length];
+  this.pathIdx++;
+  return { color: `hsl(${hue}, 70%, 45%)`, star };
 };
 
 PathSumIII.prototype.addControls = function() {
@@ -259,8 +277,9 @@ PathSumIII.prototype.reset = function() {
   this.codeIDs = [];
   this.sumLabelIDs = [];
   this.countLabelID = -1;
-  this.pathLoopIDs = [];
+  this.pathHighlightIDs = [];
   this.pathIdx = 0;
+  this.starCounts = {};
 };
 
 PathSumIII.prototype.startCallback = function() {
@@ -274,9 +293,19 @@ PathSumIII.prototype.findPaths = function() {
   this.commands = [];
   for (const id of this.sumLabelIDs) this.cmd("Delete", id);
   this.sumLabelIDs = [];
-  for (const id of this.pathLoopIDs) this.cmd("Delete", id);
-  this.pathLoopIDs = [];
+  for (const item of this.pathHighlightIDs) {
+    if (item.type === "edge") {
+      this.cmd("Disconnect", item.from, item.to);
+    }
+  }
+  for (const item of this.pathHighlightIDs) {
+    if (item.type === "node") {
+      this.cmd("Delete", item.id);
+    }
+  }
+  this.pathHighlightIDs = [];
   this.pathIdx = 0;
+  this.starCounts = {};
   for (const id in this.nodeValue) {
     this.cmd("SetBackgroundColor", parseInt(id), "#FFF");
   }
@@ -284,10 +313,6 @@ PathSumIII.prototype.findPaths = function() {
   let count = 0;
   const prefix = { 0: [-1] };
   const path = [];
-  const visitID = this.nextIndex++;
-  this.cmd("CreateHighlightCircle", visitID, "#FF0000", 0, 0, 20);
-  this.cmd("Step");
-
   const highlight = (line) => {
     for (let i = 0; i < this.codeIDs.length; i++) {
       this.cmd("SetHighlight", this.codeIDs[i], i === line ? 1 : 0);
@@ -295,60 +320,42 @@ PathSumIII.prototype.findPaths = function() {
   };
 
   const showPath = (nodes) => {
-    const color = this.pathColors[this.pathIdx % this.pathColors.length];
-    // gather node coordinates
-    const xs = nodes.map((id) => this.nodeX[id]);
-    const ys = nodes.map((id) => this.nodeY[id]);
+    const style = this.nextPathStyle();
+    const color = style.color;
+    const starGlyph = style.star;
+    let prevAnchor = null;
+    let prevX = null;
+    for (const nid of nodes) {
+      const sx = this.nodeX[nid];
+      const sy = this.nodeY[nid];
+      const idx = this.starCounts[nid] || 0;
+      const radius = 25;
+      const angle = (idx * 45 * Math.PI) / 180;
+      const starX = sx + radius * Math.cos(angle);
+      const starY = sy - radius * Math.sin(angle);
+      this.starCounts[nid] = idx + 1;
+      const starID = this.nextIndex++;
+      this.cmd("CreateLabel", starID, starGlyph, starX, starY, 0);
+      this.cmd("SetTextColor", starID, color);
+      this.cmd("SetTextStyle", starID, "bold 20");
+      this.cmd("Step");
+      this.pathHighlightIDs.push({ type: "node", id: starID });
 
-    // center of ellipse at average position
-    const centerX = xs.reduce((a, b) => a + b, 0) / xs.length;
-    const centerY = ys.reduce((a, b) => a + b, 0) / ys.length;
+      // hidden anchor for connecting colored lines through stars
+      const anchorID = this.nextIndex++;
+      this.cmd("CreateCircle", anchorID, "", starX, starY);
+      this.cmd("SetAlpha", anchorID, 0);
+      this.pathHighlightIDs.push({ type: "node", id: anchorID });
 
-    // orientation approximated by line from first to last node
-    let theta = 0;
-    if (nodes.length > 1) {
-      const dx = xs[xs.length - 1] - xs[0];
-      const dy = ys[ys.length - 1] - ys[0];
-      theta = Math.atan2(dy, dx);
+      if (prevAnchor !== null) {
+        const curve = prevX !== null && starX < prevX ? -0.2 : 0.2;
+        this.cmd("Connect", prevAnchor, anchorID, color, curve, true, "", 0);
+        this.cmd("Step");
+        this.pathHighlightIDs.push({ type: "edge", from: prevAnchor, to: anchorID });
+      }
+      prevAnchor = anchorID;
+      prevX = starX;
     }
-    const cosT = Math.cos(theta);
-    const sinT = Math.sin(theta);
-
-    // rotate points into local frame to get tight bounds.
-    // pad generously so the node circles (radius ~20)
-    // are completely enclosed by the ellipse
-    const pad = 35;
-    const localXs = [];
-    const localYs = [];
-    for (let i = 0; i < xs.length; i++) {
-      const dx = xs[i] - centerX;
-      const dy = ys[i] - centerY;
-      const lx = dx * cosT + dy * sinT;
-      const ly = -dx * sinT + dy * cosT;
-      localXs.push(lx);
-      localYs.push(ly);
-    }
-    const minX = Math.min(...localXs) - pad;
-    const maxX = Math.max(...localXs) + pad;
-    const minY = Math.min(...localYs) - pad;
-    const maxY = Math.max(...localYs) + pad;
-    const width = maxX - minX;
-    const height = maxY - minY;
-
-    const ovalID = this.nextIndex++;
-    this.cmd(
-      "CreateHighlightOval",
-      ovalID,
-      color,
-      centerX,
-      centerY,
-      width,
-      height,
-      theta
-    );
-    this.cmd("Step");
-    this.pathLoopIDs.push(ovalID);
-    this.pathIdx++;
   };
 
   const dfs = (nodeID, cur) => {
@@ -358,9 +365,6 @@ PathSumIII.prototype.findPaths = function() {
       highlight(5);
       return 0;
     }
-    this.cmd("SetHighlight", nodeID, 1); // red outline for nodes on current path
-    this.cmd("SetBackgroundColor", nodeID, "#ADD8E6");
-    this.cmd("Step");
     highlight(6);
     const val = this.nodeValue[nodeID];
     cur += val;
@@ -396,8 +400,6 @@ PathSumIII.prototype.findPaths = function() {
     const label = this.sumLabelIDs.pop();
     this.cmd("Delete", label);
     path.pop();
-    this.cmd("SetBackgroundColor", nodeID, "#FFF");
-    this.cmd("SetHighlight", nodeID, 0);
     this.cmd("Step");
     return 0;
   };
@@ -413,8 +415,6 @@ PathSumIII.prototype.findPaths = function() {
   this.cmd("Step");
   highlight(4);
   this.cmd("Step");
-  this.cmd("Delete", visitID);
-
   return this.commands;
 };
 

--- a/PathSumIII.html
+++ b/PathSumIII.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Path Sum III (LeetCode 437) - Ellipse Highlight</title>
+    <title>Path Sum III (LeetCode 437) - Star Path Highlight</title>
     <link rel="stylesheet" href="visualizationPageStyle.css" />
     <link rel="stylesheet" href="ThirdParty/jquery-ui-1.8.11.custom.css" />
     <script src="ThirdParty/jquery-1.5.2.min.js"></script>
@@ -14,8 +14,6 @@
     <script type="text/javascript" src="AnimationLibrary/AnimatedCircle.js"></script>
     <script type="text/javascript" src="AnimationLibrary/AnimatedRectangle.js"></script>
     <script type="text/javascript" src="AnimationLibrary/AnimatedLinkedList.js"></script>
-    <script type="text/javascript" src="AnimationLibrary/HighlightCircle.js"></script>
-    <script type="text/javascript" src="AnimationLibrary/HighlightOval.js"></script>
     <script type="text/javascript" src="AnimationLibrary/Line.js"></script>
     <script type="text/javascript" src="AnimationLibrary/ObjectManager.js"></script>
     <script type="text/javascript" src="AnimationLibrary/AnimationMain.js"></script>
@@ -25,7 +23,7 @@
   <body onload="init();" class="VisualizationMainPage">
     <div id="container">
       <div id="header">
-        <h1 id="title" style="font-size:24px;font-weight:bold;">Path Sum III (LeetCode 437) - Ellipse Highlight</h1>
+        <h1 id="title" style="font-size:24px;font-weight:bold;">Path Sum III (LeetCode 437) - Star Path Highlight</h1>
       </div>
       <div id="mainContent">
         <div id="algoControlSection">


### PR DESCRIPTION
## Summary
- Link path nodes with star markers offset from each tree node
- Draw matching-colored curved lines between stars to trace each path sum
- Assign a unique star glyph and color to every identified path
- Spread colored stars around shared nodes to avoid overlaps

## Testing
- `node --check AlgorithmLibrary/PathSumIII.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd8725e910832c88568a3b3c79d290