### PR TITLE
Increase font sizes for Subarray Sum Equals K visualization

### DIFF
--- a/AlgorithmLibrary/SubarraySumEqualsK.js
+++ b/AlgorithmLibrary/SubarraySumEqualsK.js
@@ -14,9 +14,12 @@ SubarraySumEqualsK.prototype.constructor = SubarraySumEqualsK;
 SubarraySumEqualsK.superclass = Algorithm.prototype;
 
 // Code panel constants
-SubarraySumEqualsK.CODE_LINE_HEIGHT = 20;
+SubarraySumEqualsK.CODE_LINE_HEIGHT = 23; // increased from 20
+SubarraySumEqualsK.CODE_FONT_SIZE = 19; // default was 16
 SubarraySumEqualsK.CODE_STANDARD_COLOR = "#000000";
 SubarraySumEqualsK.CODE_HIGHLIGHT_COLOR = "#FF0000";
+// Array element font size
+SubarraySumEqualsK.ARRAY_FONT_SIZE = 23; // default was 20
 
 // Java implementation displayed beside the animation
 SubarraySumEqualsK.CODE = [
@@ -132,6 +135,7 @@ SubarraySumEqualsK.prototype.setup = function() {
     const y = ARR_START_Y;
     this.arrRectIDs.push(id);
     this.cmd("CreateRectangle", id, String(this.arr[i]), RECT_W, RECT_H, x, y);
+    this.cmd("SetTextSize", id, SubarraySumEqualsK.ARRAY_FONT_SIZE);
   }
 
   // Prefix sum and count labels
@@ -171,6 +175,13 @@ SubarraySumEqualsK.prototype.setup = function() {
     SubarraySumEqualsK.CODE_LINE_HEIGHT,
     SubarraySumEqualsK.CODE_STANDARD_COLOR
   );
+
+  // Increase pseudocode font size
+  for (const line of this.codeID) {
+    for (const id of line) {
+      this.cmd("SetTextSize", id, SubarraySumEqualsK.CODE_FONT_SIZE);
+    }
+  }
 
   this.cmd("Step");
   return this.commands;


### PR DESCRIPTION
## Summary
- Enlarge displayed array element numbers by 3px for clearer visuals
- Bump pseudocode font size and line spacing by 3px for readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bee666fd24832cb526b0f7f68de1df