### PR TITLE
Center code block and stabilize array iteration highlighting

### DIFF
--- a/AlgorithmLibrary/Algorithm.js
+++ b/AlgorithmLibrary/Algorithm.js
@@ -135,9 +135,10 @@ Algorithm.prototype.setCodeAlpha = function(code, newAlpha)
 }
 
 
-Algorithm.prototype.addCodeToCanvasBase  = function(code, start_x, start_y, line_height, standard_color, layer)
+Algorithm.prototype.addCodeToCanvasBase  = function(code, start_x, start_y, line_height, standard_color, layer, centered)
 {
         layer = typeof layer !== 'undefined' ? layer : 0;
+        centered = typeof centered !== 'undefined' ? centered : 0;
 	var codeID = Array(code.length);
 	var i, j;
 	for (i = 0; i < code.length; i++)
@@ -146,7 +147,7 @@ Algorithm.prototype.addCodeToCanvasBase  = function(code, start_x, start_y, line
 		for (j = 0; j < code[i].length; j++)
 		{
 			codeID[i][j] = this.nextIndex++;
-			this.cmd("CreateLabel", codeID[i][j], code[i][j], start_x, start_y + i * line_height, 0);
+			this.cmd("CreateLabel", codeID[i][j], code[i][j], start_x, start_y + i * line_height, centered);
 			this.cmd("SetForegroundColor", codeID[i][j], standard_color);
 			this.cmd("SetLayer", codeID[i][j], layer);
 			if (j > 0)

--- a/AlgorithmLibrary/SubarraySumEqualsK.js
+++ b/AlgorithmLibrary/SubarraySumEqualsK.js
@@ -168,13 +168,15 @@ SubarraySumEqualsK.prototype.setup = function() {
 
   // Pseudocode display centered below the map
   const CODE_START_Y = VAR_START_Y + 140;
-  const CODE_START_X = CANVAS_W / 2 - 140; // approximate center
+  const CODE_CENTER_X = CANVAS_W/2;
   this.codeID = this.addCodeToCanvasBase(
     SubarraySumEqualsK.CODE,
-    CODE_START_X,
+    CODE_CENTER_X,
     CODE_START_Y,
     SubarraySumEqualsK.CODE_LINE_HEIGHT,
-    SubarraySumEqualsK.CODE_STANDARD_COLOR
+    SubarraySumEqualsK.CODE_STANDARD_COLOR,
+    0,
+    1
   );
 
   // Increase pseudocode font size
@@ -272,6 +274,7 @@ SubarraySumEqualsK.prototype.doAlgorithm = function() {
     this.cmd("SetForegroundColor", this.codeID[8][0], SubarraySumEqualsK.CODE_STANDARD_COLOR);
 
     this.cmd("SetBackgroundColor", rectID, "#FFFFFF");
+    this.cmd("Step");
   }
 
   this.cmd("SetForegroundColor", this.codeID[10][0], SubarraySumEqualsK.CODE_HIGHLIGHT_COLOR);


### PR DESCRIPTION
## Summary
- Center pseudo-code in Subarray Sum Equals K visualization using optional centering flag in `addCodeToCanvasBase`.
- Add step delay when clearing array highlight to prevent flicker during iteration.

## Testing
- `node -c AlgorithmLibrary/Algorithm.js`
- `node -c AlgorithmLibrary/SubarraySumEqualsK.js`


------
https://chatgpt.com/codex/tasks/task_e_68beff6a0fa4832ca7726afb1cc053b9