### PR TITLE
Fix negative number prefix animation in Subarray Sum Equals K visualization

### DIFF
--- a/AlgorithmLibrary/SubarraySumEqualsK.js
+++ b/AlgorithmLibrary/SubarraySumEqualsK.js
@@ -240,7 +240,8 @@ SubarraySumEqualsK.prototype.doAlgorithm = function() {
     
     this.cmd("SetForegroundColor", this.codeID[5][0], SubarraySumEqualsK.CODE_HIGHLIGHT_COLOR);
     const moveID = this.nextIndex++;
-    this.cmd("CreateLabel", moveID, "+" + this.arr[i], this.arrRectX[i], this.arrRectY[i]);
+    const moveText = this.arr[i] >= 0 ? "+" + this.arr[i] : String(this.arr[i]);
+    this.cmd("CreateLabel", moveID, moveText, this.arrRectX[i], this.arrRectY[i]);
     this.cmd("Move", moveID, this.prefixValueX, this.prefixValueY);
     this.cmd("Step");
     this.cmd("Delete", moveID);


### PR DESCRIPTION
## Summary
- Ensure negative array values animate as subtraction when updating prefix

## Testing
- `node --check AlgorithmLibrary/SubarraySumEqualsK.js`
- `node -e "const arr=[1,2,3,-1]; console.log(arr.map(n=>n>=0? '+'+n: ''+n));"`
- `node -e "const arr=[1,2,3,-1]; let prefix=0; arr.forEach(n=>{prefix+=n; console.log(prefix);});"`

------
https://chatgpt.com/codex/tasks/task_e_68bf23f4d984832ca67cd2bf037e5a4a