### PR TITLE
feat: show map contains evaluation

### DIFF
--- a/AlgorithmLibrary/SubarraySumEqualsK.js
+++ b/AlgorithmLibrary/SubarraySumEqualsK.js
@@ -52,6 +52,8 @@ SubarraySumEqualsK.prototype.init = function(am, w, h) {
   this.countValueID = -1;
   this.mapLabelID = -1;
   this.mapValueID = -1;
+  this.containsLabelID = -1;
+  this.containsValueID = -1;
   this.codeID = [];
   
   // initial render via animation manager
@@ -140,40 +142,66 @@ SubarraySumEqualsK.prototype.setup = function() {
     this.cmd("CreateRectangle", id, String(this.arr[i]), RECT_W, RECT_H, x, y);
   }
   
-  // Prefix sum and count labels
-  const VAR_START_Y = ARR_START_Y + 80;
-  const VAR_X = 80;
-  
-  // Variable labels and values aligned in two columns
-  const VAR_LABEL_X = VAR_X;
-  const VAR_VALUE_X = VAR_LABEL_X + 100;
+  // Layout variables in a 3x2 invisible grid
+  const GRID_START_Y = ARR_START_Y + 80;
+  const GRID_START_X = 80;
+  // widen columns so the second row cells don't crowd each other
+  const CELL_W = 260;
+  const CELL_H = 40;
 
+  // Row 1, Col 1 : prefix and its value
+  const PREFIX_X = GRID_START_X;
+  const PREFIX_Y = GRID_START_Y;
   this.prefixLabelID = this.nextIndex++;
   this.prefixValueID = this.nextIndex++;
-  this.cmd("CreateLabel", this.prefixLabelID, "prefix", VAR_LABEL_X, VAR_START_Y, 0);
-  this.cmd("CreateLabel", this.prefixValueID, "0", VAR_VALUE_X, VAR_START_Y, 0);
-  this.prefixValueX = VAR_VALUE_X;
-  this.prefixValueY = VAR_START_Y;
+  this.cmd("CreateLabel", this.prefixLabelID, "prefix", PREFIX_X, PREFIX_Y, 0);
+  this.cmd("CreateLabel", this.prefixValueID, "0", PREFIX_X + 60, PREFIX_Y, 0);
+  this.prefixValueX = PREFIX_X + 60;
+  this.prefixValueY = PREFIX_Y;
   this.cmd("SetTextStyle", this.prefixLabelID, "bold 18");
-  this.cmd("SetTextStyle", this.prefixValueID, "bold 18");
+  this.cmd("SetTextStyle", this.prefixValueID, 18);
 
+  // Row 2, Col 1 : map contains {prefix-k} and its result
+  const CONTAINS_X = GRID_START_X;
+  const CONTAINS_Y = GRID_START_Y + CELL_H;
+  this.containsLabelID = this.nextIndex++;
+  this.containsValueID = this.nextIndex++;
+  this.cmd(
+    "CreateLabel",
+    this.containsLabelID,
+    "map contains {prefix-k}",
+    CONTAINS_X,
+    CONTAINS_Y,
+    0
+  );
+  // value placed with extra padding so it doesn't collide with count column
+  this.cmd("CreateLabel", this.containsValueID, "", CONTAINS_X + 160, CONTAINS_Y, 0);
+  this.cmd("SetTextStyle", this.containsLabelID, 18);
+  this.cmd("SetTextStyle", this.containsValueID, 18);
+
+  // Row 2, Col 2 : count and its value
+  const COUNT_X = GRID_START_X + CELL_W;
+  const COUNT_Y = GRID_START_Y + CELL_H;
   this.countLabelID = this.nextIndex++;
   this.countValueID = this.nextIndex++;
-  this.cmd("CreateLabel", this.countLabelID, "count", VAR_LABEL_X, VAR_START_Y + 40, 0);
-  this.cmd("CreateLabel", this.countValueID, "0", VAR_VALUE_X, VAR_START_Y + 40, 0);
+  this.cmd("CreateLabel", this.countLabelID, "count", COUNT_X, COUNT_Y, 0);
+  this.cmd("CreateLabel", this.countValueID, "0", COUNT_X + 60, COUNT_Y, 0);
   this.cmd("SetTextStyle", this.countLabelID, "bold 18");
   this.cmd("SetTextStyle", this.countValueID, "bold 18");
 
-  // Map display as dictionary, start empty until algorithm begins
+  // Row 3 : map and its value spanning both columns
+  const MAP_X = GRID_START_X;
+  const MAP_Y = GRID_START_Y + CELL_H * 2;
   this.mapLabelID = this.nextIndex++;
   this.mapValueID = this.nextIndex++;
-  this.cmd("CreateLabel", this.mapLabelID, "map", VAR_LABEL_X, VAR_START_Y + 80, 0);
-  this.cmd("CreateLabel", this.mapValueID, "{}", VAR_VALUE_X, VAR_START_Y + 80, 0);
-  this.cmd("SetTextStyle", this.mapLabelID, "bold 18");
-  this.cmd("SetTextStyle", this.mapValueID, "bold 18");
-  
+  this.cmd("CreateLabel", this.mapLabelID, "map", MAP_X, MAP_Y, 0);
+  // map value displayed without a leading colon
+  this.cmd("CreateLabel", this.mapValueID, "{}", MAP_X + 60, MAP_Y, 0);
+  this.cmd("SetTextStyle", this.mapLabelID, 18);
+  this.cmd("SetTextStyle", this.mapValueID, 18);
+
   // Pseudocode display centered below the map
-  const CODE_START_Y = VAR_START_Y + 140;
+  const CODE_START_Y = GRID_START_Y + 180;
   const CODE_START_X = CANVAS_W / 2 - 140; // approximate center
   this.codeID = this.addCodeToCanvasBase(
     SubarraySumEqualsK.CODE,
@@ -208,7 +236,10 @@ SubarraySumEqualsK.prototype.doAlgorithm = function() {
   // show variables with an empty map before seeding
   this.cmd("SetText", this.prefixValueID, prefix);
   this.cmd("SetText", this.countValueID, count);
+  this.cmd("SetText", this.mapLabelID, "map");
   this.cmd("SetText", this.mapValueID, "{}");
+  this.cmd("SetText", this.containsLabelID, "map contains {prefix-k}");
+  this.cmd("SetText", this.containsValueID, "");
   
   // Highlight function signature and initialization lines
   this.cmd("SetForegroundColor", this.codeID[0][0], SubarraySumEqualsK.CODE_HIGHLIGHT_COLOR);
@@ -252,8 +283,11 @@ SubarraySumEqualsK.prototype.doAlgorithm = function() {
     
     this.cmd("SetForegroundColor", this.codeID[6][0], SubarraySumEqualsK.CODE_HIGHLIGHT_COLOR);
     const need = prefix - this.k;
+    this.cmd("SetText", this.containsLabelID, `map contains {${need}}`);
+    const contains = map[need] != null;
+    this.cmd("SetText", this.containsValueID, contains ? "true" : "false");
     this.cmd("Step");
-    if (map[need] != null) {
+    if (contains) {
       this.cmd("SetForegroundColor", this.codeID[7][0], SubarraySumEqualsK.CODE_HIGHLIGHT_COLOR);
       count += map[need];
       this.cmd("SetText", this.countValueID, count);


### PR DESCRIPTION
## Summary
- space out `map contains {prefix-k}` result so it no longer overlaps with `count`
- display map contents without a leading colon, updating text directly from `formatMap`
- widen second-row columns for clearer separation and ensure map label omits trailing colon
- render prefix value, `map contains {prefix-k}`, and map labels in normal weight for visual consistency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfca61a63c832cbafcfc9be0408235