### PR TITLE
fix: normalize variable value font weight

### DIFF
--- a/AlgorithmLibrary/SubarraySumEqualsK.js
+++ b/AlgorithmLibrary/SubarraySumEqualsK.js
@@ -159,7 +159,7 @@ SubarraySumEqualsK.prototype.setup = function() {
   this.prefixValueX = PREFIX_X + 60;
   this.prefixValueY = PREFIX_Y;
   this.cmd("SetTextStyle", this.prefixLabelID, "bold 18");
-  this.cmd("SetTextStyle", this.prefixValueID, 18);
+  this.cmd("SetTextStyle", this.prefixValueID, "18");
 
   // Row 2, Col 1 : map contains {prefix-k} and its result
   const CONTAINS_X = GRID_START_X;
@@ -176,8 +176,8 @@ SubarraySumEqualsK.prototype.setup = function() {
   );
   // value placed with extra padding so it doesn't collide with count column
   this.cmd("CreateLabel", this.containsValueID, "", CONTAINS_X + 160, CONTAINS_Y, 0);
-  this.cmd("SetTextStyle", this.containsLabelID, 18);
-  this.cmd("SetTextStyle", this.containsValueID, 18);
+  this.cmd("SetTextStyle", this.containsLabelID, "18");
+  this.cmd("SetTextStyle", this.containsValueID, "18");
 
 
   // Row 2, Col 2 : count and its value
@@ -188,7 +188,7 @@ SubarraySumEqualsK.prototype.setup = function() {
   this.cmd("CreateLabel", this.countLabelID, "count", COUNT_X, COUNT_Y, 0);
   this.cmd("CreateLabel", this.countValueID, "0", COUNT_X + 60, COUNT_Y, 0);
   this.cmd("SetTextStyle", this.countLabelID, "bold 18");
-  this.cmd("SetTextStyle", this.countValueID, "bold 18");
+  this.cmd("SetTextStyle", this.countValueID, "18");
 
   // Row 3 : map and its value spanning both columns
   const MAP_X = GRID_START_X;
@@ -198,8 +198,8 @@ SubarraySumEqualsK.prototype.setup = function() {
   this.cmd("CreateLabel", this.mapLabelID, "map", MAP_X, MAP_Y, 0);
   // map value displayed without a leading colon
   this.cmd("CreateLabel", this.mapValueID, "{}", MAP_X + 60, MAP_Y, 0);
-  this.cmd("SetTextStyle", this.mapLabelID, 18);
-  this.cmd("SetTextStyle", this.mapValueID, 18);
+  this.cmd("SetTextStyle", this.mapLabelID, "18");
+  this.cmd("SetTextStyle", this.mapValueID, "18");
   // Pseudocode display centered below the map
   const CODE_START_Y = GRID_START_Y + 180;
   const CODE_START_X = CANVAS_W / 2 - 140; // approximate center


### PR DESCRIPTION
## Summary
- Ensure prefix, map containment, count, and map values render with normal font weight in Subarray Sum Equals K visualization

## Testing
- `node --check AlgorithmLibrary/SubarraySumEqualsK.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c02121d2b8832cab5bb044793568a4