### PR TITLE
Increase pseudocode font size in SubarraySumEqualsK visualization

### DIFF
--- a/AlgorithmLibrary/SubarraySumEqualsK.js
+++ b/AlgorithmLibrary/SubarraySumEqualsK.js
@@ -14,7 +14,9 @@ SubarraySumEqualsK.prototype.constructor = SubarraySumEqualsK;
 SubarraySumEqualsK.superclass = Algorithm.prototype;
 
 // Code panel constants
-SubarraySumEqualsK.CODE_LINE_HEIGHT = 20;
+// Display the pseudocode slightly larger for readability
+SubarraySumEqualsK.CODE_FONT_SIZE = 17;
+SubarraySumEqualsK.CODE_LINE_HEIGHT = 23;
 SubarraySumEqualsK.CODE_STANDARD_COLOR = "#000000";
 SubarraySumEqualsK.CODE_HIGHLIGHT_COLOR = "#FF0000";
 
@@ -216,6 +218,17 @@ SubarraySumEqualsK.prototype.setup = function() {
     SubarraySumEqualsK.CODE_LINE_HEIGHT,
     SubarraySumEqualsK.CODE_STANDARD_COLOR
   );
+
+  // Apply larger font size to the pseudocode display
+  for (let i = 0; i < this.codeID.length; i++) {
+    for (let j = 0; j < this.codeID[i].length; j++) {
+      this.cmd(
+        "SetTextStyle",
+        this.codeID[i][j],
+        String(SubarraySumEqualsK.CODE_FONT_SIZE)
+      );
+    }
+  }
   
   this.cmd("Step");
   return this.commands;


### PR DESCRIPTION
## Summary
- Enlarge pseudocode font size for Subarray Sum Equals K visualization by introducing `CODE_FONT_SIZE` and adjusting line height.
- Apply the new font size to every pseudocode line to improve readability.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c031ae41ac832c855b90632d1bdba6