### PR TITLE
Add DFS prefix-sum animation for Path Sum III

### DIFF
--- a/PathSumIII.html
+++ b/PathSumIII.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Path Sum III (LeetCode 437) - Curved Path Highlights</title>
+    <title>PathSumIII (Leetcode 437)</title>
     <link rel="stylesheet" href="visualizationPageStyle.css" />
     <link rel="stylesheet" href="ThirdParty/jquery-ui-1.8.11.custom.css" />
     <script src="ThirdParty/jquery-1.5.2.min.js"></script>
@@ -12,8 +12,8 @@
     <script type="text/javascript" src="AnimationLibrary/AnimatedObject.js"></script>
     <script type="text/javascript" src="AnimationLibrary/AnimatedLabel.js"></script>
     <script type="text/javascript" src="AnimationLibrary/AnimatedCircle.js"></script>
-    <script type="text/javascript" src="AnimationLibrary/AnimatedRectangle.js"></script>
     <script type="text/javascript" src="AnimationLibrary/AnimatedLinkedList.js"></script>
+    <script type="text/javascript" src="AnimationLibrary/HighlightCircle.js"></script>
     <script type="text/javascript" src="AnimationLibrary/Line.js"></script>
     <script type="text/javascript" src="AnimationLibrary/ObjectManager.js"></script>
     <script type="text/javascript" src="AnimationLibrary/AnimationMain.js"></script>
@@ -23,7 +23,7 @@
   <body onload="init();" class="VisualizationMainPage">
     <div id="container">
       <div id="header">
-        <h1 id="title" style="font-size:24px;font-weight:bold;">Path Sum III (LeetCode 437) - Curved Path Highlights</h1>
+        <h1 style="text-align: center; font-weight: bold;">PathSumIII (Leetcode 437)</h1>
       </div>
       <div id="mainContent">
         <div id="algoControlSection">


### PR DESCRIPTION
## Summary
- remove rectangle outlines and stretch grid to canvas width
- center pseudocode block and keep code structure left-aligned
- sync DFS traversal steps with code highlighting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f681840c832cb19ea111e0deac54