### PR TITLE
Center PathSumIII visualization

### DIFF
--- a/AlgorithmLibrary/PathSumIII.js
+++ b/AlgorithmLibrary/PathSumIII.js
@@ -243,7 +243,7 @@ PathSumIII.prototype.setup = function () {
   }
 
   // grid layout constants
-  const CANVAS_W = 540;
+  const CANVAS_W = canvasElem ? canvasElem.width : 540;
   const firstColW = 200; // wider first column for long labels
   const otherColW = (CANVAS_W - firstColW) / 4;
   this.firstColW = firstColW;
@@ -322,7 +322,7 @@ PathSumIII.prototype.setup = function () {
     maxWidth =
       PathSumIII.CODE_FONT_SIZE * 0.6 * Math.max(...PathSumIII.CODE.map((s) => s.length));
   }
-  const codeStartX = CANVAS_W / 2 - maxWidth / 2;
+  const codeStartX = (CANVAS_W - maxWidth) / 2;
   const codeStartY = row3Y + this.cellH / 2 + 60;
   for (let i = 0; i < PathSumIII.CODE.length; i++) {
     const id = this.nextIndex++;

--- a/PathSumIII.html
+++ b/PathSumIII.html
@@ -29,7 +29,12 @@
         <div id="algoControlSection">
           <table id="AlgorithmSpecificControls"></table>
         </div>
-        <canvas id="canvas" width="540" height="960"></canvas>
+        <canvas
+          id="canvas"
+          width="540"
+          height="960"
+          style="display: block; margin: 10px auto;"
+        ></canvas>
         <div id="generalAnimationControlSection">
           <table id="GeneralAnimationControls"></table>
         </div>


### PR DESCRIPTION
## Summary
- Center PathSumIII code block horizontally on the canvas using actual canvas width while keeping text left-aligned
- Center the PathSumIII canvas element on the page via inline styling

## Testing
- `node --check AlgorithmLibrary/PathSumIII.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c12b7925ec832c80eeed036572d3c2