### PR TITLE
Center PathSumIII visualization

### DIFF
--- a/AlgorithmLibrary/PathSumIII.js
+++ b/AlgorithmLibrary/PathSumIII.js
@@ -243,7 +243,7 @@ PathSumIII.prototype.setup = function () {
   }
 
   // grid layout constants
-  const CANVAS_W = 540;
+  const CANVAS_W = canvasElem ? canvasElem.width : 540;
   const firstColW = 200; // wider first column for long labels
   const otherColW = (CANVAS_W - firstColW) / 4;
   this.firstColW = firstColW;
@@ -310,19 +310,23 @@ PathSumIII.prototype.setup = function () {
 
   // code block centered horizontally (left-aligned text)
   let maxWidth = 0;
+  let ctx;
   if (canvasElem) {
-    const ctx = canvasElem.getContext("2d");
+    ctx = canvasElem.getContext("2d");
     ctx.font = PathSumIII.CODE_FONT_SIZE + "px Arial";
-    for (let i = 0; i < PathSumIII.CODE.length; i++) {
-      const w = ctx.measureText(PathSumIII.CODE[i]).width;
+    for (const line of PathSumIII.CODE) {
+      const w = ctx.measureText(line).width;
       if (w > maxWidth) maxWidth = w;
     }
-  }
-  if (maxWidth === 0) {
+    if (maxWidth === 0) {
+      const charW = ctx.measureText("M").width || PathSumIII.CODE_FONT_SIZE * 0.6;
+      maxWidth = charW * Math.max(...PathSumIII.CODE.map((s) => s.length));
+    }
+  } else {
     maxWidth =
       PathSumIII.CODE_FONT_SIZE * 0.6 * Math.max(...PathSumIII.CODE.map((s) => s.length));
   }
-  const codeStartX = CANVAS_W / 2 - maxWidth / 2;
+  const codeStartX = (CANVAS_W - maxWidth) / 2;
   const codeStartY = row3Y + this.cellH / 2 + 60;
   for (let i = 0; i < PathSumIII.CODE.length; i++) {
     const id = this.nextIndex++;

--- a/PathSumIII.html
+++ b/PathSumIII.html
@@ -29,7 +29,12 @@
         <div id="algoControlSection">
           <table id="AlgorithmSpecificControls"></table>
         </div>
-        <canvas id="canvas" width="540" height="960"></canvas>
+        <canvas
+          id="canvas"
+          width="540"
+          height="960"
+          style="display: block; margin: 10px auto;"
+        ></canvas>
         <div id="generalAnimationControlSection">
           <table id="GeneralAnimationControls"></table>
         </div>


### PR DESCRIPTION
## Summary
- Center PathSumIII code block horizontally using canvas text measurement with width fallback
- Center the PathSumIII canvas element on the page via inline styling

## Testing
- `node --check AlgorithmLibrary/PathSumIII.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c12b7925ec832c80eeed036572d3c2