### PR TITLE
Center PathSumIII visualization

### DIFF
--- a/AlgorithmLibrary/PathSumIII.js
+++ b/AlgorithmLibrary/PathSumIII.js
@@ -172,13 +172,35 @@ PathSumIII.prototype.layoutTree = function (root) {
 PathSumIII.prototype.setup = function () {
   this.commands = [];
 
+  // Measure code width first so we can size the canvas accordingly
+  let maxWidth = 0;
+  const measureCtx = document.createElement("canvas").getContext("2d");
+  if (measureCtx) {
+    measureCtx.font = PathSumIII.CODE_FONT_SIZE + "px Arial";
+    for (const line of PathSumIII.CODE) {
+      const w = measureCtx.measureText(line).width;
+      if (w > maxWidth) maxWidth = w;
+    }
+    if (maxWidth === 0) {
+      const charW =
+        measureCtx.measureText("M").width || PathSumIII.CODE_FONT_SIZE * 0.6;
+      maxWidth = charW * Math.max(...PathSumIII.CODE.map((s) => s.length));
+    }
+  } else {
+    maxWidth =
+      PathSumIII.CODE_FONT_SIZE * 0.6 * Math.max(...PathSumIII.CODE.map((s) => s.length));
+  }
+
+  const baseW = 540;
+  const canvasW = Math.max(baseW, Math.ceil(maxWidth) + 20);
+  const canvasH = 960;
   const canvasElem = document.getElementById("canvas");
   if (canvasElem) {
-    canvasElem.width = 540;
-    canvasElem.height = 960;
+    canvasElem.width = canvasW;
+    canvasElem.height = canvasH;
     if (animationManager?.animatedObjects) {
-      animationManager.animatedObjects.width = 540;
-      animationManager.animatedObjects.height = 960;
+      animationManager.animatedObjects.width = canvasW;
+      animationManager.animatedObjects.height = canvasH;
     }
   }
 
@@ -201,7 +223,8 @@ PathSumIII.prototype.setup = function () {
 
   // title on canvas
   this.titleID = this.nextIndex++;
-  this.cmd("CreateLabel", this.titleID, "PathSumIII (Leetcode 437)", 270, 40, 1);
+  const titleX = (canvasElem ? canvasElem.width : canvasW) / 2;
+  this.cmd("CreateLabel", this.titleID, "PathSumIII (Leetcode 437)", titleX, 40, 1);
   this.cmd("SetTextStyle", this.titleID, "bold 24");
 
   // draw tree
@@ -243,7 +266,7 @@ PathSumIII.prototype.setup = function () {
   }
 
   // grid layout constants
-  const CANVAS_W = 540;
+  const CANVAS_W = canvasElem ? canvasElem.width : canvasW;
   const firstColW = 200; // wider first column for long labels
   const otherColW = (CANVAS_W - firstColW) / 4;
   this.firstColW = firstColW;
@@ -309,20 +332,7 @@ PathSumIII.prototype.setup = function () {
   this.updateContainsLabel();
 
   // code block centered horizontally (left-aligned text)
-  let maxWidth = 0;
-  if (canvasElem) {
-    const ctx = canvasElem.getContext("2d");
-    ctx.font = PathSumIII.CODE_FONT_SIZE + "px Arial";
-    for (let i = 0; i < PathSumIII.CODE.length; i++) {
-      const w = ctx.measureText(PathSumIII.CODE[i]).width;
-      if (w > maxWidth) maxWidth = w;
-    }
-  }
-  if (maxWidth === 0) {
-    maxWidth =
-      PathSumIII.CODE_FONT_SIZE * 0.6 * Math.max(...PathSumIII.CODE.map((s) => s.length));
-  }
-  const codeStartX = CANVAS_W / 2 - maxWidth / 2;
+  const codeStartX = (CANVAS_W - maxWidth) / 2;
   const codeStartY = row3Y + this.cellH / 2 + 60;
   for (let i = 0; i < PathSumIII.CODE.length; i++) {
     const id = this.nextIndex++;

--- a/PathSumIII.html
+++ b/PathSumIII.html
@@ -29,7 +29,12 @@
         <div id="algoControlSection">
           <table id="AlgorithmSpecificControls"></table>
         </div>
-        <canvas id="canvas" width="540" height="960"></canvas>
+        <canvas
+          id="canvas"
+          width="540"
+          height="960"
+          style="display: block; margin: 10px auto;"
+        ></canvas>
         <div id="generalAnimationControlSection">
           <table id="GeneralAnimationControls"></table>
         </div>


### PR DESCRIPTION
## Summary
- Resize PathSumIII canvas based on code width to prevent truncation
- Center code block and title using new dynamic canvas size

## Testing
- `node --check AlgorithmLibrary/PathSumIII.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c12b7925ec832c80eeed036572d3c2