### PR TITLE
Center PathSumIII visualization and ensure animation runs

### DIFF
--- a/PathSumIII.html
+++ b/PathSumIII.html
@@ -29,7 +29,12 @@
         <div id="algoControlSection">
           <table id="AlgorithmSpecificControls"></table>
         </div>
-        <canvas id="canvas" width="540" height="960"></canvas>
+        <canvas
+          id="canvas"
+          width="540"
+          height="960"
+          style="display: block; margin: 10px auto;"
+        ></canvas>
         <div id="generalAnimationControlSection">
           <table id="GeneralAnimationControls"></table>
         </div>


### PR DESCRIPTION
## Summary
- Auto-build default PathSumIII example on load so animation starts immediately
- Use default tree when no input is provided and clean up tree builder

## Testing
- `node --check AlgorithmLibrary/PathSumIII.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c12b7925ec832c80eeed036572d3c2