### PR TITLE
Use containsKey for PathSumIII count lookup and center code

### DIFF
--- a/AlgorithmLibrary/PathSumIII.js
+++ b/AlgorithmLibrary/PathSumIII.js
@@ -30,7 +30,8 @@ PathSumIII.CODE = [
   "int dfs(TreeNode node, int prefix, int k, Map<Integer,Integer> map) {",
   "    if (node == null) return 0;",
   "    prefix += node.val;",
-  "    int count = map.getOrDefault(prefix - k, 0);",
+  "    int count = 0;",
+  "    if (map.containsKey(prefix - k)) count = map.get(prefix - k);",
   "    map.put(prefix, map.getOrDefault(prefix, 0) + 1);",
   "    count += dfs(node.left, prefix, k, map);",
   "    count += dfs(node.right, prefix, k, map);",
@@ -70,8 +71,9 @@ PathSumIII.prototype.init = function (am, w, h) {
 
   this.travID = -1;
 
-  // default setup
+  // build default example on load
   this.reset();
+  this.buildTreeCallback();
 };
 
 PathSumIII.prototype.addControls = function () {
@@ -108,11 +110,16 @@ PathSumIII.prototype.addControls = function () {
 
 PathSumIII.prototype.buildTreeCallback = function () {
   const raw = this.inputField.value.trim();
-  if (raw.length === 0) return;
-  const vals = raw
-    .split(/[\s,]+/)
-    .map((v) => (v === "null" || v === "NULL" || v === "None" ? null : parseInt(v)));
-  this.arr = vals;
+  if (raw.length > 0) {
+    this.arr = raw
+      .split(/[\s,]+/)
+      .map((v) =>
+        v === "null" || v === "NULL" || v === "None" ? null : parseInt(v)
+      );
+  } else {
+    // fall back to default example when no input provided
+    this.arr = [10, 5, -3, 3, 2, null, 11, 3, -2, null, 1];
+  }
   const t = parseInt(this.kField.value);
   if (!isNaN(t)) this.k = t;
   this.reset();
@@ -131,7 +138,6 @@ function TreeNode(val) {
 PathSumIII.prototype.buildTreeFromArray = function (arr) {
   if (!arr || arr.length === 0 || arr[0] === null) return null;
   const root = new TreeNode(arr[0]);
-  1;
   const queue = [root];
   let i = 1;
   while (queue.length > 0 && i < arr.length) {
@@ -172,13 +178,35 @@ PathSumIII.prototype.layoutTree = function (root) {
 PathSumIII.prototype.setup = function () {
   this.commands = [];
 
+  // Measure code width first so we can size the canvas accordingly
+  let maxWidth = 0;
+  const measureCtx = document.createElement("canvas").getContext("2d");
+  if (measureCtx) {
+    measureCtx.font = PathSumIII.CODE_FONT_SIZE + "px Arial";
+    for (const line of PathSumIII.CODE) {
+      const w = measureCtx.measureText(line).width;
+      if (w > maxWidth) maxWidth = w;
+    }
+    if (maxWidth === 0) {
+      const charW =
+        measureCtx.measureText("M").width || PathSumIII.CODE_FONT_SIZE * 0.6;
+      maxWidth = charW * Math.max(...PathSumIII.CODE.map((s) => s.length));
+    }
+  } else {
+    maxWidth =
+      PathSumIII.CODE_FONT_SIZE * 0.6 * Math.max(...PathSumIII.CODE.map((s) => s.length));
+  }
+
+  const baseW = 540;
+  const canvasW = Math.max(baseW, Math.ceil(maxWidth) + 20);
+  const canvasH = 960;
   const canvasElem = document.getElementById("canvas");
   if (canvasElem) {
-    canvasElem.width = 540;
-    canvasElem.height = 960;
-    if (animationManager?.animatedObjects) {
-      animationManager.animatedObjects.width = 540;
-      animationManager.animatedObjects.height = 960;
+    canvasElem.width = canvasW;
+    canvasElem.height = canvasH;
+    if (animationManager && animationManager.animatedObjects) {
+      animationManager.animatedObjects.width = canvasW;
+      animationManager.animatedObjects.height = canvasH;
     }
   }
 
@@ -201,7 +229,8 @@ PathSumIII.prototype.setup = function () {
 
   // title on canvas
   this.titleID = this.nextIndex++;
-  this.cmd("CreateLabel", this.titleID, "PathSumIII (Leetcode 437)", 270, 40, 1);
+  const titleX = (canvasElem ? canvasElem.width : canvasW) / 2;
+  this.cmd("CreateLabel", this.titleID, "PathSumIII (Leetcode 437)", titleX, 40, 1);
   this.cmd("SetTextStyle", this.titleID, "bold 24");
 
   // draw tree
@@ -243,7 +272,7 @@ PathSumIII.prototype.setup = function () {
   }
 
   // grid layout constants
-  const CANVAS_W = 540;
+  const CANVAS_W = canvasElem ? canvasElem.width : canvasW;
   const firstColW = 200; // wider first column for long labels
   const otherColW = (CANVAS_W - firstColW) / 4;
   this.firstColW = firstColW;
@@ -309,20 +338,7 @@ PathSumIII.prototype.setup = function () {
   this.updateContainsLabel();
 
   // code block centered horizontally (left-aligned text)
-  let maxWidth = 0;
-  if (canvasElem) {
-    const ctx = canvasElem.getContext("2d");
-    ctx.font = PathSumIII.CODE_FONT_SIZE + "px Arial";
-    for (let i = 0; i < PathSumIII.CODE.length; i++) {
-      const w = ctx.measureText(PathSumIII.CODE[i]).width;
-      if (w > maxWidth) maxWidth = w;
-    }
-  }
-  if (maxWidth === 0) {
-    maxWidth =
-      PathSumIII.CODE_FONT_SIZE * 0.6 * Math.max(...PathSumIII.CODE.map((s) => s.length));
-  }
-  const codeStartX = CANVAS_W / 2 - maxWidth / 2;
+  const codeStartX = Math.round((CANVAS_W - maxWidth) / 2);
   const codeStartY = row3Y + this.cellH / 2 + 60;
   for (let i = 0; i < PathSumIII.CODE.length; i++) {
     const id = this.nextIndex++;
@@ -418,7 +434,16 @@ PathSumIII.prototype.runDFS = function () {
 
   // create traversal highlight circle
   this.travID = this.nextIndex++;
-  this.cmd("CreateHighlightCircle", this.travID, "#FF0000", this.nodeX[this.rootID], this.nodeY[this.rootID]);
+  this.cmd(
+    "CreateHighlightCircle",
+    this.travID,
+    "#FF0000",
+    this.nodeX[this.rootID],
+    this.nodeY[this.rootID]
+  );
+  // start at the root so first movement is visible
+  this.cmd("Move", this.travID, this.nodeX[this.rootID], this.nodeY[this.rootID]);
+  this.cmd("Step");
 
   const dfs = (nodeID, prefix) => {
     this.highlight(6);
@@ -426,9 +451,9 @@ PathSumIII.prototype.runDFS = function () {
     if (nodeID == null) {
       return 0;
     }
-    this.cmd("Move", this.travID, this.nodeX[nodeID], this.nodeY[nodeID]);
-    this.cmd("Step");
     this.cmd("SetHighlight", nodeID, 1);
+    this.cmd("SetBackgroundColor", nodeID, "#FFAAAA");
+    this.cmd("Step");
 
     this.highlight(7);
     this.cmd("Step");
@@ -437,88 +462,109 @@ PathSumIII.prototype.runDFS = function () {
     const text = val >= 0 ? "+" + val : String(val);
     this.cmd("CreateLabel", moveID, text, this.nodeX[nodeID], this.nodeY[nodeID]);
     this.cmd("Move", moveID, this.prefixValueX, this.prefixValueY);
+    this.cmd("SetForegroundColor", this.prefixValueID, "#FF0000");
     this.cmd("Step");
     this.cmd("Delete", moveID);
     prefix += val;
     this.cmd("SetText", this.prefixValueID, String(prefix));
+    this.cmd("SetForegroundColor", this.prefixValueID, "#000000");
     this.cmd("Step");
 
     this.highlight(8);
+    this.cmd("Step");
+    let countLocal = 0;
+
+    this.highlight(9);
     this.cmd("Step");
     const need = prefix - this.k;
     this.cmd("SetText", this.containsLabelID, `map.containsKey(${need})`);
     const contains = this.updateContainsLabel(need);
     this.cmd("Step");
-    let countLocal = contains ? this.map[need] : 0;
     if (contains) {
       const entry = this.mapEntryIDs[need];
       if (entry) {
-        this.cmd("SetBackgroundColor", entry.id, "#FF9999");
+        this.cmd("SetForegroundColor", entry.id, "#FF0000");
         const mv = this.nextIndex++;
         this.cmd("CreateLabel", mv, "+" + this.map[need], entry.x, this.mapValueY);
         this.cmd("Move", mv, this.countValueX, this.countValueY);
+        this.cmd("SetForegroundColor", this.countValueID, "#FF0000");
         this.cmd("Step");
         this.cmd("Delete", mv);
-        this.cmd("SetBackgroundColor", entry.id, "#FFFFFF");
+        this.cmd("SetForegroundColor", this.countValueID, "#000000");
+        this.cmd("SetForegroundColor", entry.id, "#000000");
       }
-      this.count += this.map[need];
+      countLocal = this.map[need];
+      this.count += countLocal;
       this.cmd("SetText", this.countValueID, String(this.count));
       this.cmd("Step");
     }
 
-    this.highlight(9);
+    this.highlight(10);
     this.cmd("Step");
     this.map[prefix] = (this.map[prefix] || 0) + 1;
     this.renderMap();
     this.cmd("Step");
 
-    this.highlight(10);
+    this.highlight(11);
     this.cmd("Step");
     if (this.leftChild[nodeID] != null) {
+      this.cmd("SetHighlight", nodeID, 0);
+      this.cmd("SetBackgroundColor", nodeID, "#FFFFFF");
       this.cmd("Move", this.travID, this.nodeX[this.leftChild[nodeID]], this.nodeY[this.leftChild[nodeID]]);
       this.cmd("Step");
       dfs(this.leftChild[nodeID], prefix);
       this.cmd("Move", this.travID, this.nodeX[nodeID], this.nodeY[nodeID]);
       this.cmd("Step");
+      this.cmd("SetHighlight", nodeID, 1);
+      this.cmd("SetBackgroundColor", nodeID, "#FFAAAA");
+      this.cmd("Step");
     }
 
-    this.highlight(11);
+    this.highlight(12);
     this.cmd("Step");
     if (this.rightChild[nodeID] != null) {
+      this.cmd("SetHighlight", nodeID, 0);
+      this.cmd("SetBackgroundColor", nodeID, "#FFFFFF");
       this.cmd("Move", this.travID, this.nodeX[this.rightChild[nodeID]], this.nodeY[this.rightChild[nodeID]]);
       this.cmd("Step");
       dfs(this.rightChild[nodeID], prefix);
       this.cmd("Move", this.travID, this.nodeX[nodeID], this.nodeY[nodeID]);
       this.cmd("Step");
+      this.cmd("SetHighlight", nodeID, 1);
+      this.cmd("SetBackgroundColor", nodeID, "#FFAAAA");
+      this.cmd("Step");
     }
 
-    this.highlight(12);
+    this.highlight(13);
     this.cmd("Step");
     this.map[prefix]--;
     if (this.map[prefix] === 0) delete this.map[prefix];
     this.renderMap();
     this.cmd("Step");
 
-    this.highlight(13);
+    this.highlight(14);
     this.cmd("Step");
     const moveID2 = this.nextIndex++;
     const text2 = val >= 0 ? "-" + val : "+" + -val;
     this.cmd("CreateLabel", moveID2, text2, this.nodeX[nodeID], this.nodeY[nodeID]);
     this.cmd("Move", moveID2, this.prefixValueX, this.prefixValueY);
+    this.cmd("SetForegroundColor", this.prefixValueID, "#FF0000");
     this.cmd("Step");
     this.cmd("Delete", moveID2);
     prefix -= val;
     this.cmd("SetText", this.prefixValueID, String(prefix));
+    this.cmd("SetForegroundColor", this.prefixValueID, "#000000");
     this.cmd("Step");
 
-    this.highlight(14);
+    this.highlight(15);
     this.cmd("Step");
     this.cmd("SetHighlight", nodeID, 0);
+    this.cmd("SetBackgroundColor", nodeID, "#FFFFFF");
     return countLocal;
   };
 
   dfs(this.rootID, 0);
-  this.highlight(15);
+  this.highlight(16);
   this.cmd("Step");
   this.enableUI();
   return this.commands;
@@ -537,6 +583,8 @@ PathSumIII.prototype.stepCallback = function () {
 
 PathSumIII.prototype.reset = function () {
   this.nextIndex = 0;
+  this.rootID = -1;
+  this.mapEntryIDs = {};
   if (typeof animationManager !== "undefined" && animationManager.animatedObjects) {
     animationManager.animatedObjects.clearAllObjects();
   }

--- a/PathSumIII.html
+++ b/PathSumIII.html
@@ -29,7 +29,12 @@
         <div id="algoControlSection">
           <table id="AlgorithmSpecificControls"></table>
         </div>
-        <canvas id="canvas" width="540" height="960"></canvas>
+        <canvas
+          id="canvas"
+          width="540"
+          height="960"
+          style="display: block; margin: 10px auto;"
+        ></canvas>
         <div id="generalAnimationControlSection">
           <table id="GeneralAnimationControls"></table>
         </div>


### PR DESCRIPTION
## Summary
- Show explicit `map.containsKey(prefix - k)` check in displayed Java code and update count only when present
- Animate the new containsKey lookup and adjust DFS highlights accordingly
- Round code block placement so the Java snippet stays centered on the canvas
- Highlight the current tree node in red and move the highlight during traversal and backtracking
- Replace optional chaining with explicit guards and reset IDs to ensure DFS animation initializes correctly

## Testing
- `node --check AlgorithmLibrary/PathSumIII.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c12b7925ec832c80eeed036572d3c2