### PR TITLE
Center DP grid and sync Partition Equal Subset Sum animation

### DIFF
--- a/AlgorithmLibrary/PartitionEqualSubsetSum.js
+++ b/AlgorithmLibrary/PartitionEqualSubsetSum.js
@@ -7,24 +7,32 @@
  * subsets with equal sum.
  */
 
-function PartitionEqualSubsetSum(am, w, h) { this.init(am, w, h); }
+function PartitionEqualSubsetSum(am, w, h) {
+  this.init(am, w, h);
+}
 
 PartitionEqualSubsetSum.prototype = new Algorithm();
 PartitionEqualSubsetSum.prototype.constructor = PartitionEqualSubsetSum;
 PartitionEqualSubsetSum.superclass = Algorithm.prototype;
 
-// Pseudocode to display
+// Java-style reference code displayed alongside animation
 PartitionEqualSubsetSum.CODE = [
-  "sum = total(nums)",
-  "if sum % 2 == 1: return false",
-  "target = sum / 2",
-  "dp[0][0] = true",
-  "for i in 1..n:",
-  "  for j in 0..target:",
-  "    dp[i][j] = dp[i-1][j]",
-  "    if j ≥ nums[i-1]:",
-  "      dp[i][j] |= dp[i-1][j-nums[i-1]]",
-  "return dp[n][target]"
+  "boolean canPartition(int[] nums) {",
+  "  int sum = total(nums);",
+  "  if (sum % 2 == 1) return false;",
+  "  int target = sum / 2;",
+  "  boolean[][] dp = new boolean[n + 1][target + 1];",
+  "  dp[0][0] = true;",
+  "  for (int i = 1; i <= n; i++) {",
+  "    for (int j = 0; j <= target; j++) {",
+  "      dp[i][j] = dp[i - 1][j];",
+  "      if (j >= nums[i - 1]) {",
+  "        dp[i][j] |= dp[i - 1][j - nums[i - 1]];",
+  "      }",
+  "    }",
+  "  }",
+  "  return dp[n][target];",
+  "}",
 ];
 
 PartitionEqualSubsetSum.prototype.init = function (am, w, h) {
@@ -74,11 +82,7 @@ PartitionEqualSubsetSum.prototype.addControls = function () {
   this.stepButton = addControlToAlgorithmBar("Button", "Next Step");
   this.stepButton.onclick = this.stepCallback.bind(this);
 
-  this.controls.push(
-    this.inputField,
-    this.buildButton,
-    this.startButton
-  );
+  this.controls.push(this.inputField, this.buildButton, this.startButton);
 };
 
 PartitionEqualSubsetSum.prototype.buildArrayCallback = function () {
@@ -103,17 +107,17 @@ PartitionEqualSubsetSum.prototype.setup = function () {
   const canvas = document.getElementById("canvas");
   const canvasW = canvas ? canvas.width : 540;
 
-  const RECT_W = 40;
-  const RECT_H = 40;
-  const RECT_SP = 5;
+  const RECT_W = 30;
+  const RECT_H = 30;
+  const RECT_SP = 4;
 
   const total = this.arr.reduce((a, b) => a + b, 0);
   const target = Math.floor(total / 2);
   const gridWidth = (target + 1) * (RECT_W + RECT_SP) - RECT_SP;
   const arrWidth = this.n * (RECT_W + RECT_SP) - RECT_SP;
   const maxWidth = Math.max(arrWidth, gridWidth);
-  const startX = Math.max(10, Math.floor((canvasW - maxWidth) / 2));
-  const startY = 80;
+  const startX = Math.floor((canvasW - maxWidth) / 2);
+  const startY = 60;
 
   this.commands = [];
   this.arrIDs = [];
@@ -150,21 +154,18 @@ PartitionEqualSubsetSum.prototype.setup = function () {
   this.targetValueX = startX + 60;
   this.targetValueY = infoY + 30;
   this.cmd("CreateLabel", this.sumLabelID, "sum:", startX, infoY, 0);
-    this.cmd("CreateLabel", this.sumValueID, "0", this.sumValueX, infoY, 0);
+  this.cmd("CreateLabel", this.sumValueID, "0", this.sumValueX, infoY, 0);
   this.cmd("CreateLabel", this.targetLabelID, "target:", startX, infoY + 30, 0);
   this.cmd("CreateLabel", this.targetValueID, "", this.targetValueX, this.targetValueY, 0);
 
   // DP matrix setup (n+1 by target+1)
-  const dpStartY = infoY + 110;
-  this.dpIDs = [];
-  this.dpX = [];
-  this.dpY = [];
+  const dpStartY = infoY + 100;
   for (let i = 0; i <= this.n; i++) {
     const rowIDs = [];
     const rowX = [];
     const rowY = [];
     const y = dpStartY + i * (RECT_H + RECT_SP);
-    // Row label: value or 0 for header row
+    // Row label
     const rlabel = this.nextIndex++;
     const rtext = i === 0 ? "0" : String(this.arr[i - 1]);
     this.cmd("CreateLabel", rlabel, rtext, startX - 30, y + RECT_H / 2, 0);
@@ -199,20 +200,16 @@ PartitionEqualSubsetSum.prototype.setup = function () {
   this.cmd("CreateLabel", this.resultLabelID, "Can Partition:", startX, resY, 0);
   this.cmd("CreateLabel", this.resultValueID, "?", startX + 140, resY, 0);
 
-  // Code lines displayed beneath result
+  // Code lines displayed beneath result, centered in canvas
   const CODE_LINE_H = 22;
   const codeY = resY + 40;
+  const maxCodeLen = Math.max(...PartitionEqualSubsetSum.CODE.map((s) => s.length));
+  const CODE_CHAR_W = 7;
+  const codeStartX = Math.floor((canvasW - maxCodeLen * CODE_CHAR_W) / 2);
   for (let i = 0; i < PartitionEqualSubsetSum.CODE.length; i++) {
     const id = this.nextIndex++;
     this.codeIDs.push(id);
-    this.cmd(
-      "CreateLabel",
-      id,
-      PartitionEqualSubsetSum.CODE[i],
-      startX,
-      codeY + i * CODE_LINE_H,
-      0
-    );
+    this.cmd("CreateLabel", id, PartitionEqualSubsetSum.CODE[i], codeStartX, codeY + i * CODE_LINE_H, 0);
     this.cmd("SetForegroundColor", id, "#000000");
   }
 
@@ -222,10 +219,7 @@ PartitionEqualSubsetSum.prototype.setup = function () {
   if (canvasElem) {
     if (canvasElem.height < neededH) {
       canvasElem.height = neededH;
-      if (
-        typeof animationManager !== "undefined" &&
-        animationManager.animatedObjects
-      ) {
+      if (typeof animationManager !== "undefined" && animationManager.animatedObjects) {
         animationManager.animatedObjects.height = neededH;
       }
     }
@@ -254,8 +248,7 @@ PartitionEqualSubsetSum.prototype.pauseCallback = function () {
 
 PartitionEqualSubsetSum.prototype.stepCallback = function () {
   if (typeof animationManager !== "undefined") {
-    if (!animationManager.animationPaused && typeof doPlayPause === "function")
-      doPlayPause();
+    if (!animationManager.animationPaused && typeof doPlayPause === "function") doPlayPause();
     animationManager.step();
   }
 };
@@ -263,7 +256,7 @@ PartitionEqualSubsetSum.prototype.stepCallback = function () {
 PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
   this.commands = [];
   let sum = 0;
-  this.highlightCode(0);
+  this.highlightCode(1); // int sum = total(nums)
   for (let i = 0; i < this.n; i++) {
     const moveID = this.nextIndex++;
     this.cmd("CreateLabel", moveID, String(this.arr[i]), this.arrX[i], this.arrY[i]);
@@ -275,44 +268,40 @@ PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
     this.cmd("Step");
   }
 
-  this.highlightCode(1);
+  this.highlightCode(2); // if odd
   if (sum % 2 === 1) {
     this.cmd("SetText", this.resultValueID, "false");
     return this.commands;
   }
 
-  this.highlightCode(2);
+  this.highlightCode(3); // target
   const target = Math.floor(sum / 2);
   this.cmd("SetText", this.targetValueID, String(target));
 
   // ensure dp matrix big enough
-  if (
-    this.dpIDs.length < this.n + 1 ||
-    (this.dpIDs[0] && this.dpIDs[0].length < target + 1)
-  ) {
+  if (this.dpIDs.length < this.n + 1 || (this.dpIDs[0] && this.dpIDs[0].length < target + 1)) {
     this.setup();
     return this.runAlgorithm();
   }
 
-  this.highlightCode(3);
-  const dp = Array.from({ length: this.n + 1 }, () =>
-    new Array(target + 1).fill(false)
-  );
+  this.highlightCode(4); // boolean[][] dp...
+  const dp = Array.from({ length: this.n + 1 }, () => new Array(target + 1).fill(false));
+  this.highlightCode(5); // dp[0][0] = true
   dp[0][0] = true;
   this.cmd("SetText", this.dpIDs[0][0], "T");
   this.cmd("SetBackgroundColor", this.dpIDs[0][0], "#dff7df");
   this.cmd("Step");
 
   for (let i = 1; i <= this.n; i++) {
-    this.highlightCode(4);
+    this.highlightCode(6); // for (int i ...)
     this.cmd("SetBackgroundColor", this.arrIDs[i - 1], "#ffe9a8");
     this.cmd("Step");
     for (let j = 0; j <= target; j++) {
-      this.highlightCode(5);
+      this.highlightCode(7); // for (int j ...)
       this.cmd("SetBackgroundColor", this.dpIDs[i][j], "#ffd4d4");
       this.cmd("SetBackgroundColor", this.dpIDs[i - 1][j], "#ffd4d4");
       this.cmd("Step");
-      this.highlightCode(6);
+      this.highlightCode(8); // dp[i][j] = dp[i - 1][j]
       if (dp[i - 1][j]) {
         dp[i][j] = true;
       }
@@ -322,14 +311,14 @@ PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
         dp[i - 1][j] ? "#dff7df" : "#eeeeee"
       );
       if (j >= this.arr[i - 1]) {
-        this.highlightCode(7);
+        this.highlightCode(9); // if (j >= nums[i - 1])
         this.cmd(
           "SetBackgroundColor",
           this.dpIDs[i - 1][j - this.arr[i - 1]],
           "#ffd4d4"
         );
         this.cmd("Step");
-        this.highlightCode(8);
+        this.highlightCode(10); // dp[i][j] |= dp[i - 1][j - nums[i - 1]]
         if (dp[i - 1][j - this.arr[i - 1]]) {
           dp[i][j] = true;
         }
@@ -350,7 +339,7 @@ PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
     this.cmd("SetBackgroundColor", this.arrIDs[i - 1], "#f0f7ff");
   }
 
-  this.highlightCode(9);
+  this.highlightCode(14); // return dp[n][target]
   this.cmd(
     "SetText",
     this.resultValueID,
@@ -371,6 +360,7 @@ PartitionEqualSubsetSum.prototype.reset = function () {
 PartitionEqualSubsetSum.prototype.disableUI = function () {
   for (let i = 0; i < this.controls.length; i++) this.controls[i].disabled = true;
 };
+
 PartitionEqualSubsetSum.prototype.enableUI = function () {
   for (let i = 0; i < this.controls.length; i++) this.controls[i].disabled = false;
 };

--- a/visualizationPageStyle.css
+++ b/visualizationPageStyle.css
@@ -125,6 +125,6 @@ EM {text-decoration: bold;}
 
 #canvas {
    border: 2px solid;
-   margin-top: 10px;
-   margin-left: 100px;
+   display: block;
+   margin: 10px auto;
 }


### PR DESCRIPTION
## Summary
- Center canvas layout and shrink DP grid rectangles for clearer view
- Display Java-style reference code and highlight steps in sync with execution
- Center code block within canvas for balanced presentation

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4123cd6d8832c94753e917b9ae0df