### PR TITLE
Center DP grid after computing target

### DIFF
--- a/AlgorithmLibrary/PartitionEqualSubsetSum.js
+++ b/AlgorithmLibrary/PartitionEqualSubsetSum.js
@@ -7,24 +7,32 @@
  * subsets with equal sum.
  */
 
-function PartitionEqualSubsetSum(am, w, h) { this.init(am, w, h); }
+function PartitionEqualSubsetSum(am, w, h) {
+  this.init(am, w, h);
+}
 
 PartitionEqualSubsetSum.prototype = new Algorithm();
 PartitionEqualSubsetSum.prototype.constructor = PartitionEqualSubsetSum;
 PartitionEqualSubsetSum.superclass = Algorithm.prototype;
 
-// Pseudocode to display
+// Java-style reference code displayed alongside animation
 PartitionEqualSubsetSum.CODE = [
-  "sum = total(nums)",
-  "if sum % 2 == 1: return false",
-  "target = sum / 2",
-  "dp[0][0] = true",
-  "for i in 1..n:",
-  "  for j in 0..target:",
-  "    dp[i][j] = dp[i-1][j]",
-  "    if j ≥ nums[i-1]:",
-  "      dp[i][j] |= dp[i-1][j-nums[i-1]]",
-  "return dp[n][target]"
+  "boolean canPartition(int[] nums) {",
+  "  int sum = total(nums);",
+  "  if (sum % 2 == 1) return false;",
+  "  int target = sum / 2;",
+  "  boolean[][] dp = new boolean[n + 1][target + 1];",
+  "  dp[0][0] = true;",
+  "  for (int i = 1; i <= n; i++) {",
+  "    for (int j = 0; j <= target; j++) {",
+  "      dp[i][j] = dp[i - 1][j];",
+  "      if (j >= nums[i - 1]) {",
+  "        dp[i][j] |= dp[i - 1][j - nums[i - 1]];",
+  "      }",
+  "    }",
+  "  }",
+  "  return dp[n][target];",
+  "}"
 ];
 
 PartitionEqualSubsetSum.prototype.init = function (am, w, h) {
@@ -43,13 +51,19 @@ PartitionEqualSubsetSum.prototype.init = function (am, w, h) {
   this.dpX = [];
   this.dpY = [];
   this.codeIDs = [];
+  this.weightLabelIDs = [];
+  this.capacityLabelIDs = [];
+  this.weightLabelIDs = [];
+  this.capacityLabelIDs = [];
 
+  this.titleID = -1;
   this.sumLabelID = -1;
   this.sumValueID = -1;
   this.targetLabelID = -1;
   this.targetValueID = -1;
   this.resultLabelID = -1;
   this.resultValueID = -1;
+  this.messageID = -1;
 
   this.setup();
 };
@@ -74,11 +88,7 @@ PartitionEqualSubsetSum.prototype.addControls = function () {
   this.stepButton = addControlToAlgorithmBar("Button", "Next Step");
   this.stepButton.onclick = this.stepCallback.bind(this);
 
-  this.controls.push(
-    this.inputField,
-    this.buildButton,
-    this.startButton
-  );
+  this.controls.push(this.inputField, this.buildButton, this.startButton);
 };
 
 PartitionEqualSubsetSum.prototype.buildArrayCallback = function () {
@@ -103,17 +113,24 @@ PartitionEqualSubsetSum.prototype.setup = function () {
   const canvas = document.getElementById("canvas");
   const canvasW = canvas ? canvas.width : 540;
 
-  const RECT_W = 40;
-  const RECT_H = 40;
-  const RECT_SP = 5;
+  const TITLE_Y = 30;
+  const RECT_W = 25;
+  const RECT_H = 25;
+  const RECT_SP = 3;
 
   const total = this.arr.reduce((a, b) => a + b, 0);
   const target = Math.floor(total / 2);
   const gridWidth = (target + 1) * (RECT_W + RECT_SP) - RECT_SP;
   const arrWidth = this.n * (RECT_W + RECT_SP) - RECT_SP;
   const maxWidth = Math.max(arrWidth, gridWidth);
-  const startX = Math.max(10, Math.floor((canvasW - maxWidth) / 2));
+  const startX = Math.floor((canvasW - maxWidth) / 2);
   const startY = 80;
+
+  this.RECT_W = RECT_W;
+  this.RECT_H = RECT_H;
+  this.RECT_SP = RECT_SP;
+  this.startX = startX;
+  this.startY = startY;
 
   this.commands = [];
   this.arrIDs = [];
@@ -123,6 +140,19 @@ PartitionEqualSubsetSum.prototype.setup = function () {
   this.dpX = [];
   this.dpY = [];
   this.codeIDs = [];
+
+  // Title centered at top of canvas
+  this.titleID = this.nextIndex++;
+  this.cmd(
+    "CreateLabel",
+    this.titleID,
+    "Bottom-Up Tabulation (0/1 Knapsack)",
+    canvasW / 2,
+    TITLE_Y,
+    1
+  );
+  this.cmd("SetForegroundColor", this.titleID, "#000000");
+  this.cmd("SetTextStyle", this.titleID, "bold 16");
 
   // Draw array numbers
   for (let i = 0; i < this.n; i++) {
@@ -134,13 +164,11 @@ PartitionEqualSubsetSum.prototype.setup = function () {
     this.cmd("CreateRectangle", id, String(this.arr[i]), RECT_W, RECT_H, x, startY);
     this.cmd("SetBackgroundColor", id, "#f0f7ff");
     this.cmd("SetForegroundColor", id, "#000000");
-    const lid = this.nextIndex++;
-    this.cmd("CreateLabel", lid, "nums[" + i + "]", x + RECT_W / 2, startY + RECT_H + 15, 1);
-    this.cmd("SetForegroundColor", lid, "#888888");
   }
 
   // Sum and target labels
-  const infoY = startY + RECT_H + 60;
+  const infoY = startY + RECT_H + 40;
+  this.infoY = infoY;
   this.sumLabelID = this.nextIndex++;
   this.sumValueID = this.nextIndex++;
   this.sumValueX = startX + 60;
@@ -150,25 +178,56 @@ PartitionEqualSubsetSum.prototype.setup = function () {
   this.targetValueX = startX + 60;
   this.targetValueY = infoY + 30;
   this.cmd("CreateLabel", this.sumLabelID, "sum:", startX, infoY, 0);
-    this.cmd("CreateLabel", this.sumValueID, "0", this.sumValueX, infoY, 0);
+  this.cmd("CreateLabel", this.sumValueID, "0", this.sumValueX, infoY, 0);
   this.cmd("CreateLabel", this.targetLabelID, "target:", startX, infoY + 30, 0);
   this.cmd("CreateLabel", this.targetValueID, "", this.targetValueX, this.targetValueY, 0);
+  this.cmd("SetTextStyle", this.sumLabelID, "bold 14");
+  this.cmd("SetTextStyle", this.targetLabelID, "bold 14");
 
-  // DP matrix setup (n+1 by target+1)
-  const dpStartY = infoY + 110;
+  // Explanatory message moved slightly left and enlarged
+  const messageX = canvasW - 220;
+  const messageY = TITLE_Y + 40;
+  this.messageID = this.nextIndex++;
+  this.cmd("CreateLabel", this.messageID, "", messageX, messageY, 0);
+  this.cmd("SetForegroundColor", this.messageID, "#003366");
+  this.cmd("SetTextStyle", this.messageID, "16");
+
+  animationManager.StartNewAnimation(this.commands);
+  animationManager.skipForward();
+  animationManager.clearHistory();
+};
+
+// Build the visual DP table once the target is known
+PartitionEqualSubsetSum.prototype.createDPGrid = function (target) {
+  const RECT_W = this.RECT_W;
+  const RECT_H = this.RECT_H;
+  const RECT_SP = this.RECT_SP;
+  const startX = this.startX;
+  const dpStartY = this.infoY + 100;
+  const gridHeight = (this.n + 1) * (RECT_H + RECT_SP) - RECT_SP;
+
+  // clear any existing grid/labels
+  for (const row of this.dpIDs) {
+    for (const id of row) this.cmd("Delete", id);
+  }
+  for (const id of this.weightLabelIDs) this.cmd("Delete", id);
+  for (const id of this.capacityLabelIDs) this.cmd("Delete", id);
+  if (this.resultLabelID !== -1) this.cmd("Delete", this.resultLabelID);
+  if (this.resultValueID !== -1) this.cmd("Delete", this.resultValueID);
+  for (const id of this.codeIDs) this.cmd("Delete", id);
+
   this.dpIDs = [];
   this.dpX = [];
   this.dpY = [];
+  this.weightLabelIDs = [];
+  this.capacityLabelIDs = [];
+  this.codeIDs = [];
+
   for (let i = 0; i <= this.n; i++) {
     const rowIDs = [];
     const rowX = [];
     const rowY = [];
     const y = dpStartY + i * (RECT_H + RECT_SP);
-    // Row label: value or 0 for header row
-    const rlabel = this.nextIndex++;
-    const rtext = i === 0 ? "0" : String(this.arr[i - 1]);
-    this.cmd("CreateLabel", rlabel, rtext, startX - 30, y + RECT_H / 2, 0);
-    this.cmd("SetForegroundColor", rlabel, "#888888");
     for (let j = 0; j <= target; j++) {
       const id = this.nextIndex++;
       const x = startX + j * (RECT_W + RECT_SP);
@@ -182,26 +241,41 @@ PartitionEqualSubsetSum.prototype.setup = function () {
     this.dpIDs.push(rowIDs);
     this.dpX.push(rowX);
     this.dpY.push(rowY);
+    if (i > 0) {
+      const vlabel = this.nextIndex++;
+      const vtext = String(this.arr[i - 1]);
+      const vlabelX = startX - (RECT_W / 2 + RECT_SP);
+      const vlabelY = y + RECT_H / 2;
+      this.cmd("CreateLabel", vlabel, vtext, vlabelX, vlabelY, 0);
+      this.cmd("SetForegroundColor", vlabel, "#888888");
+      this.weightLabelIDs.push(vlabel);
+    }
   }
 
-  // Column labels
-  const colY = dpStartY + (this.n + 1) * (RECT_H + RECT_SP);
+  const gridBottomY = dpStartY + gridHeight;
+  const capLabelY = gridBottomY + (RECT_H / 2 + RECT_SP);
   for (let j = 0; j <= target; j++) {
     const lid = this.nextIndex++;
     const x = startX + j * (RECT_W + RECT_SP) + RECT_W / 2;
-    this.cmd("CreateLabel", lid, String(j), x, colY + 15, 1);
+    this.cmd("CreateLabel", lid, String(j), x, capLabelY, 0);
     this.cmd("SetForegroundColor", lid, "#888888");
+    this.capacityLabelIDs.push(lid);
   }
 
   this.resultLabelID = this.nextIndex++;
   this.resultValueID = this.nextIndex++;
-  const resY = colY + 40;
+  const resY = capLabelY + 40;
   this.cmd("CreateLabel", this.resultLabelID, "Can Partition:", startX, resY, 0);
   this.cmd("CreateLabel", this.resultValueID, "?", startX + 140, resY, 0);
+  this.cmd("SetTextStyle", this.resultLabelID, "bold 14");
 
-  // Code lines displayed beneath result
   const CODE_LINE_H = 22;
   const codeY = resY + 40;
+  const canvas = document.getElementById("canvas");
+  const canvasW = canvas ? canvas.width : 540;
+  const maxCodeLen = Math.max(...PartitionEqualSubsetSum.CODE.map((s) => s.length));
+  const CODE_CHAR_W = 7;
+  const codeStartX = Math.floor((canvasW - maxCodeLen * CODE_CHAR_W) / 2);
   for (let i = 0; i < PartitionEqualSubsetSum.CODE.length; i++) {
     const id = this.nextIndex++;
     this.codeIDs.push(id);
@@ -209,31 +283,23 @@ PartitionEqualSubsetSum.prototype.setup = function () {
       "CreateLabel",
       id,
       PartitionEqualSubsetSum.CODE[i],
-      startX,
+      codeStartX,
       codeY + i * CODE_LINE_H,
       0
     );
     this.cmd("SetForegroundColor", id, "#000000");
   }
 
-  // extend canvas height if needed
   const neededH = codeY + PartitionEqualSubsetSum.CODE.length * CODE_LINE_H + 80;
   const canvasElem = document.getElementById("canvas");
   if (canvasElem) {
     if (canvasElem.height < neededH) {
       canvasElem.height = neededH;
-      if (
-        typeof animationManager !== "undefined" &&
-        animationManager.animatedObjects
-      ) {
+      if (typeof animationManager !== "undefined" && animationManager.animatedObjects) {
         animationManager.animatedObjects.height = neededH;
       }
     }
   }
-
-  animationManager.StartNewAnimation(this.commands);
-  animationManager.skipForward();
-  animationManager.clearHistory();
 };
 
 PartitionEqualSubsetSum.prototype.highlightCode = function (line) {
@@ -254,8 +320,7 @@ PartitionEqualSubsetSum.prototype.pauseCallback = function () {
 
 PartitionEqualSubsetSum.prototype.stepCallback = function () {
   if (typeof animationManager !== "undefined") {
-    if (!animationManager.animationPaused && typeof doPlayPause === "function")
-      doPlayPause();
+    if (!animationManager.animationPaused && typeof doPlayPause === "function") doPlayPause();
     animationManager.step();
   }
 };
@@ -263,7 +328,9 @@ PartitionEqualSubsetSum.prototype.stepCallback = function () {
 PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
   this.commands = [];
   let sum = 0;
-  this.highlightCode(0);
+  this.highlightCode(1); // int sum = total(nums)
+  this.cmd("SetText", this.messageID, "Computing total sum");
+  this.cmd("Step");
   for (let i = 0; i < this.n; i++) {
     const moveID = this.nextIndex++;
     this.cmd("CreateLabel", moveID, String(this.arr[i]), this.arrX[i], this.arrY[i]);
@@ -272,47 +339,47 @@ PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
     this.cmd("Delete", moveID);
     sum += this.arr[i];
     this.cmd("SetText", this.sumValueID, String(sum));
+    this.cmd("SetText", this.messageID, "Sum = " + sum);
     this.cmd("Step");
   }
 
-  this.highlightCode(1);
+  this.highlightCode(2); // if odd
   if (sum % 2 === 1) {
     this.cmd("SetText", this.resultValueID, "false");
+    this.cmd("SetText", this.messageID, "Total sum is odd -> cannot partition");
     return this.commands;
   }
 
-  this.highlightCode(2);
+  this.highlightCode(3); // target
   const target = Math.floor(sum / 2);
   this.cmd("SetText", this.targetValueID, String(target));
+  this.cmd("SetText", this.messageID, "Target = " + target);
+  this.cmd("Step");
 
-  // ensure dp matrix big enough
-  if (
-    this.dpIDs.length < this.n + 1 ||
-    (this.dpIDs[0] && this.dpIDs[0].length < target + 1)
-  ) {
-    this.setup();
-    return this.runAlgorithm();
-  }
+  this.createDPGrid(target);
+  this.cmd("Step");
 
-  this.highlightCode(3);
-  const dp = Array.from({ length: this.n + 1 }, () =>
-    new Array(target + 1).fill(false)
-  );
+  this.highlightCode(4); // boolean[][] dp...
+  const dp = Array.from({ length: this.n + 1 }, () => new Array(target + 1).fill(false));
+  this.highlightCode(5); // dp[0][0] = true
   dp[0][0] = true;
   this.cmd("SetText", this.dpIDs[0][0], "T");
   this.cmd("SetBackgroundColor", this.dpIDs[0][0], "#dff7df");
+  this.cmd("SetText", this.messageID, "Base case: dp[0][0] = true");
   this.cmd("Step");
 
   for (let i = 1; i <= this.n; i++) {
-    this.highlightCode(4);
+    this.highlightCode(6); // for (int i ...)
     this.cmd("SetBackgroundColor", this.arrIDs[i - 1], "#ffe9a8");
+    this.cmd("SetText", this.messageID, "Considering number " + this.arr[i - 1]);
     this.cmd("Step");
     for (let j = 0; j <= target; j++) {
-      this.highlightCode(5);
+      this.highlightCode(7); // for (int j ...)
       this.cmd("SetBackgroundColor", this.dpIDs[i][j], "#ffd4d4");
       this.cmd("SetBackgroundColor", this.dpIDs[i - 1][j], "#ffd4d4");
+      this.cmd("SetText", this.messageID, "Try sum " + j);
       this.cmd("Step");
-      this.highlightCode(6);
+      this.highlightCode(8); // dp[i][j] = dp[i - 1][j]
       if (dp[i - 1][j]) {
         dp[i][j] = true;
       }
@@ -322,14 +389,14 @@ PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
         dp[i - 1][j] ? "#dff7df" : "#eeeeee"
       );
       if (j >= this.arr[i - 1]) {
-        this.highlightCode(7);
+        this.highlightCode(9); // if (j >= nums[i - 1])
         this.cmd(
           "SetBackgroundColor",
           this.dpIDs[i - 1][j - this.arr[i - 1]],
           "#ffd4d4"
         );
         this.cmd("Step");
-        this.highlightCode(8);
+        this.highlightCode(10); // dp[i][j] |= dp[i - 1][j - nums[i - 1]]
         if (dp[i - 1][j - this.arr[i - 1]]) {
           dp[i][j] = true;
         }
@@ -345,16 +412,24 @@ PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
         this.dpIDs[i][j],
         dp[i][j] ? "#dff7df" : "#eeeeee"
       );
+      if (dp[i][j]) {
+        this.cmd("SetText", this.messageID, "Found sum " + j);
+      }
       this.cmd("Step");
     }
     this.cmd("SetBackgroundColor", this.arrIDs[i - 1], "#f0f7ff");
   }
 
-  this.highlightCode(9);
+  this.highlightCode(14); // return dp[n][target]
   this.cmd(
     "SetText",
     this.resultValueID,
     dp[this.n][target] ? "true" : "false"
+  );
+  this.cmd(
+    "SetText",
+    this.messageID,
+    dp[this.n][target] ? "Partition possible" : "No partition"
   );
   this.cmd("Step");
   return this.commands;
@@ -371,6 +446,7 @@ PartitionEqualSubsetSum.prototype.reset = function () {
 PartitionEqualSubsetSum.prototype.disableUI = function () {
   for (let i = 0; i < this.controls.length; i++) this.controls[i].disabled = true;
 };
+
 PartitionEqualSubsetSum.prototype.enableUI = function () {
   for (let i = 0; i < this.controls.length; i++) this.controls[i].disabled = false;
 };

--- a/visualizationPageStyle.css
+++ b/visualizationPageStyle.css
@@ -125,6 +125,6 @@ EM {text-decoration: bold;}
 
 #canvas {
    border: 2px solid;
-   margin-top: 10px;
-   margin-left: 100px;
+   display: block;
+   margin: 10px auto;
 }


### PR DESCRIPTION
## Summary
- Build and render the DP table only after computing the target to keep the visualization in sync with algorithm logic
- Ensure weight labels and capacity markers are centered beside rows and below columns in the DP grid

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4123cd6d8832c94753e917b9ae0df