### PR TITLE
Add caption and outro to Partition Equal Subset Sum animation

### DIFF
--- a/AlgorithmLibrary/Algorithm.js
+++ b/AlgorithmLibrary/Algorithm.js
@@ -370,13 +370,46 @@ Algorithm.prototype.undo = function(event)
 	{
 		this.actionHistory[i][0](this.actionHistory[i][1]);
 	}
-	this.recordAnimation = true;
+        this.recordAnimation = true;
 }
 
 
+// Display a caption centered near the bottom of the canvas using an
+// AnimatedLabel. Returns the ID of the created label so it can be
+// removed later.
+Algorithm.prototype.displayCaption = function(text)
+{
+        var captionID = this.nextIndex++;
+        this.cmd("CreateLabel", captionID, text,
+                 this.canvasWidth / 2, this.canvasHeight - 20, 0);
+        this.cmd("SetForegroundColor", captionID, "#000000");
+        this.cmd("SetLayer", captionID, 3);
+        return captionID;
+}
+
+// Remove a caption previously created with displayCaption
+Algorithm.prototype.removeCaption = function(id)
+{
+        this.cmd("Delete", id);
+}
+
+// Show an outro slide encouraging viewers to subscribe or comment.
+// The slide remains on screen for two animation steps (~2-3 seconds)
+// before being removed.
+Algorithm.prototype.showOutroSlide = function(text)
+{
+        var outroID = this.nextIndex++;
+        this.cmd("CreateLabel", outroID, text,
+                 this.canvasWidth / 2, this.canvasHeight / 2, 0);
+        this.cmd("SetLayer", outroID, 3);
+        this.cmd("Step");
+        this.cmd("Step");
+        this.cmd("Delete", outroID);
+}
+
 Algorithm.prototype.clearHistory = function()
 {
-	this.actionHistory = [];
+        this.actionHistory = [];
 }
 		
 		// Helper method to add text input with nice border.

--- a/AlgorithmLibrary/PartitionEqualSubsetSum.js
+++ b/AlgorithmLibrary/PartitionEqualSubsetSum.js
@@ -329,6 +329,7 @@ PartitionEqualSubsetSum.prototype.stepCallback = function () {
 PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
   this.commands = [];
   let sum = 0;
+  var captionID = this.displayCaption("Computing total sum");
   this.highlightCode(1); // int sum = total(nums)
   this.cmd("SetText", this.messageID, "Computing total sum");
   this.cmd("Step");
@@ -343,13 +344,21 @@ PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
     this.cmd("SetText", this.messageID, "Sum = " + sum);
     this.cmd("Step");
   }
-
+  
+  this.removeCaption(captionID);
+  captionID = this.displayCaption("Checking if sum is odd");
   this.highlightCode(2); // if odd
   if (sum % 2 === 1) {
     this.cmd("SetText", this.resultValueID, "false");
     this.cmd("SetText", this.messageID, "Total sum is odd -> cannot partition");
+    this.removeCaption(captionID);
+    captionID = this.displayCaption("Total sum is odd - cannot partition");
+    this.cmd("Step");
+    this.removeCaption(captionID);
+    this.showOutroSlide("Thanks for watching! Subscribe and comment!");
     return this.commands;
   }
+  this.removeCaption(captionID);
 
   this.highlightCode(3); // target
   const target = Math.floor(sum / 2);
@@ -357,6 +366,7 @@ PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
   this.cmd("SetText", this.messageID, "Target = " + target);
   this.cmd("Step");
 
+  captionID = this.displayCaption("Building DP table");
   this.createDPGrid(target);
   this.cmd("Step");
 
@@ -370,6 +380,8 @@ PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
   this.cmd("Step");
 
   for (let i = 1; i <= this.n; i++) {
+    this.removeCaption(captionID);
+    captionID = this.displayCaption("Considering number " + this.arr[i - 1]);
     this.highlightCode(6); // for (int i ...)
     this.cmd("SetBackgroundColor", this.arrIDs[i - 1], "#ffe9a8");
     this.cmd("SetText", this.messageID, "Considering number " + this.arr[i - 1]);
@@ -420,7 +432,8 @@ PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
     }
     this.cmd("SetBackgroundColor", this.arrIDs[i - 1], "#f0f7ff");
   }
-
+ 
+  this.removeCaption(captionID);
   this.highlightCode(14); // return dp[n][target]
   this.cmd(
     "SetText",
@@ -432,7 +445,12 @@ PartitionEqualSubsetSum.prototype.runAlgorithm = function () {
     this.messageID,
     dp[this.n][target] ? "Partition possible" : "No partition"
   );
+  captionID = this.displayCaption(
+    dp[this.n][target] ? "Partition possible" : "No partition"
+  );
   this.cmd("Step");
+  this.removeCaption(captionID);
+  this.showOutroSlide("Thanks for watching! Subscribe and comment!");
   return this.commands;
 };
 


### PR DESCRIPTION
## Summary
- add caption and outro helper methods using `AnimatedLabel`
- show step captions and a final subscribe/comment message in Partition Equal Subset Sum visualization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c666a61310832c8a757b773d7a548e