### PR TITLE
Improve DFS start vertex lookup compatibility

### DIFF
--- a/AnimationLibrary/AnimatedRectangle.js
+++ b/AnimationLibrary/AnimatedRectangle.js
@@ -44,7 +44,8 @@ AnimatedRectangle = function(id, val, wth, hgt,  xJust, yJust, fillColor, edgeCo
         this.alpha = 1.0;
         this.addedToScene = true;
         this.textSize = "bold 16";
-	
+        this.lineThickness = 1;
+
 }
 
 AnimatedRectangle.prototype = new AnimatedObject();
@@ -52,12 +53,22 @@ AnimatedRectangle.prototype.constructor = AnimatedRectangle;
 
 AnimatedRectangle.prototype.setNull = function(np)
 {
-	this.nullPointer = np;
+        this.nullPointer = np;
 }
 
 AnimatedRectangle.prototype.getNull = function()
 {
-	return this.nullPointer;
+        return this.nullPointer;
+}
+
+AnimatedRectangle.prototype.setLineThickness = function(thickness)
+{
+        this.lineThickness = thickness;
+}
+
+AnimatedRectangle.prototype.getLineThickness = function()
+{
+        return this.lineThickness;
 }
 
 
@@ -237,7 +248,7 @@ AnimatedRectangle.prototype.draw = function(context)
 		labelPosY = this.y - this.h / 2.0;
 	}
 	
-	context.lineWidth = 1;
+        context.lineWidth = this.lineThickness;
 	
 	if (this.highlighted)
 	{
@@ -304,7 +315,21 @@ AnimatedRectangle.prototype.setTextStyle = function(style)
 AnimatedRectangle.prototype.createUndoDelete = function() 
 {
 	// TODO: Add color?
-	return new UndoDeleteRectangle(this.objectID, this.label, this.x, this.y, this.w, this.h, this.xJustify, this.yJustify, this.backgroundColor, this.foregroundColor, this.highlighted, this.layer);
+        return new UndoDeleteRectangle(
+                this.objectID,
+                this.label,
+                this.x,
+                this.y,
+                this.w,
+                this.h,
+                this.xJustify,
+                this.yJustify,
+                this.backgroundColor,
+                this.foregroundColor,
+                this.highlighted,
+                this.layer,
+                this.lineThickness
+        );
 }
 
 AnimatedRectangle.prototype.setHighlight = function(value)
@@ -314,10 +339,10 @@ AnimatedRectangle.prototype.setHighlight = function(value)
 
 
 
-function UndoDeleteRectangle(id, lab, x, y, w, h, xJust, yJust, bgColor, fgColor, highlight, lay)
+function UndoDeleteRectangle(id, lab, x, y, w, h, xJust, yJust, bgColor, fgColor, highlight, lay, lineThickness)
 {
-	this.objectID = id;
-	this.posX = x;
+        this.objectID = id;
+        this.posX = x;
 	this.posY = y;
 	this.width = w;
 	this.height = h;
@@ -325,9 +350,10 @@ function UndoDeleteRectangle(id, lab, x, y, w, h, xJust, yJust, bgColor, fgColor
 	this.yJustify = yJust;
 	this.backgroundColor= bgColor;
 	this.foregroundColor = fgColor;
-	this.nodeLabel = lab;
-	this.layer = lay;
-	this.highlighted = highlight;
+        this.nodeLabel = lab;
+        this.layer = lay;
+        this.highlighted = highlight;
+        this.lineThickness = lineThickness;
 }
 
 UndoDeleteRectangle.prototype = new UndoBlock();
@@ -336,10 +362,11 @@ UndoDeleteRectangle.prototype.constructor = UndoDeleteRectangle;
 
 UndoDeleteRectangle.prototype.undoInitialStep = function(world)
 {
-	world.addRectangleObject(this.objectID, this.nodeLabel, this.width, this.height, this.xJustify, this.yJustify, this.backgroundColor, this.foregroundColor);
-	world.setNodePosition(this.objectID, this.posX, this.posY);
-	world.setLayer(this.objectID, this.layer);
-	world.setHighlight(this.objectID, this.highlighted);
+        world.addRectangleObject(this.objectID, this.nodeLabel, this.width, this.height, this.xJustify, this.yJustify, this.backgroundColor, this.foregroundColor);
+        world.setNodePosition(this.objectID, this.posX, this.posY);
+        world.setLayer(this.objectID, this.layer);
+        world.setHighlight(this.objectID, this.highlighted);
+        world.setRectangleLineThickness(this.objectID, this.lineThickness);
 }
 
 

--- a/AnimationLibrary/AnimationMain.js
+++ b/AnimationLibrary/AnimationMain.js
@@ -112,8 +112,7 @@ function returnSubmit(field, funct, maxsize, intOnly)
 		if(window.event) // IE
 		{
 			keyASCII = event.keyCode
-		}
-		else if (event.which) // Netscape/Firefox/Opera
+		} else if (event.which) // Netscape/Firefox/Opera
 		{
 			keyASCII = event.which
 		} 
@@ -122,12 +121,10 @@ function returnSubmit(field, funct, maxsize, intOnly)
 		{
 			funct();
                         return false;
-		}
-        	else if (keyASCII == 59  || keyASCII == 45 || keyASCII == 46 || keyASCII == 190 || keyASCII == 173)
+		} else if (keyASCII == 59  || keyASCII == 45 || keyASCII == 46 || keyASCII == 190 || keyASCII == 173)
 		{
 		       return false;	
-		} 
-		else if (maxsize != undefined && field.value.length >= maxsize ||
+		} else if (maxsize != undefined && field.value.length >= maxsize ||
 				 intOnly && (keyASCII < 48 || keyASCII > 57))
 
 		{
@@ -227,8 +224,7 @@ function doPlayPause()
 			stepBackButton.disabled = false;		
 		}
 		
-	}
-	else
+	} else
 	{
 		playPauseBackButton.setAttribute("value", "pause");	
 	}
@@ -344,8 +340,7 @@ function initCanvas()
 	if (speed == null || speed == "")
 	{
 		speed = ANIMATION_SPEED_DEFAULT;
-	}
-	else
+	} else
 	{
 		speed = parseInt(speed);
 	}
@@ -390,8 +385,7 @@ function initCanvas()
 	if (width == null || width == "")
 	{
 		width = canvas.width;
-	}
-	else
+	} else
 	{
 		width = parseInt(width);
 	}
@@ -399,8 +393,7 @@ function initCanvas()
 	if (height == null || height == "")
 	{
 		height = canvas.height;
-	}
-	else
+	} else
 	{
 		height = parseInt(height);
 	}
@@ -538,8 +531,7 @@ function AnimationManager(objectManager)
 			if (clr.charAt(0) == "#")
 			{
 				return clr;
-			}
-			else if (clr.substring(0,2) == "0x")
+			} else if (clr.substring(0,2) == "0x")
 			{
 				return "#" + clr.substring(2);
 			}
@@ -605,8 +597,7 @@ function AnimationManager(objectManager)
 				}
 				undoBlock.push(new UndoCreate(parseInt(nextCommand[1])));
 
-			}
-			else if (nextCommand[0].toUpperCase() == "CONNECT")
+			} else if (nextCommand[0].toUpperCase() == "CONNECT")
 			{
 				
 				if (nextCommand.length > 7)
@@ -618,8 +609,7 @@ function AnimationManager(objectManager)
                                                                          this.parseBool(nextCommand[5]), 
                                                                          nextCommand[6], 
                                                                          parseInt(nextCommand[7]));
-				}
-				else if (nextCommand.length > 6)
+				} else if (nextCommand.length > 6)
 				{
 					this.animatedObjects.connectEdge(parseInt(nextCommand[1]), 
                                                                          parseInt(nextCommand[2]),
@@ -628,8 +618,7 @@ function AnimationManager(objectManager)
                                                                          this.parseBool(nextCommand[5]),
                                                                          nextCommand[6],
                                                                          0);
-				}
-				else if (nextCommand.length > 5)
+				} else if (nextCommand.length > 5)
 				{
 					this.animatedObjects.connectEdge(parseInt(nextCommand[1]), 
                                                                          parseInt(nextCommand[2]),
@@ -638,8 +627,7 @@ function AnimationManager(objectManager)
                                                                          this.parseBool(nextCommand[5]),
                                                                          "",
                                                                          0);
-				}
-				else if (nextCommand.length > 4)
+				} else if (nextCommand.length > 4)
 				{
 					this.animatedObjects.connectEdge(parseInt(nextCommand[1]),
                                                                          parseInt(nextCommand[2]),
@@ -648,8 +636,7 @@ function AnimationManager(objectManager)
                                                                          true,
                                                                          "",
                                                                          0);
-				}
-				else if (nextCommand.length > 3)
+				} else if (nextCommand.length > 3)
 				{
 					this.animatedObjects.connectEdge(parseInt(nextCommand[1]),
                                                                          parseInt(nextCommand[2]),
@@ -658,8 +645,7 @@ function AnimationManager(objectManager)
                                                                          true,
                                                                          "",
                                                                          0);
-				}
-				else
+				} else
 				{
 					this.animatedObjects.connectEdge(parseInt(nextCommand[1]),
                                                                          parseInt(nextCommand[2]),
@@ -671,8 +657,7 @@ function AnimationManager(objectManager)
 					
 				}
 				undoBlock.push(new UndoConnect(parseInt(nextCommand[1]), parseInt (nextCommand[2]), false));
-			}
-			else if (nextCommand[0].toUpperCase() == "CREATERECTANGLE")
+			} else if (nextCommand[0].toUpperCase() == "CREATERECTANGLE")
 			{
 				if (nextCommand.length == 9)
 				{
@@ -684,8 +669,7 @@ function AnimationManager(objectManager)
 															nextCommand[8],// yJustify
 															"#ffffff", // background color
 					                                        "#000000"); // foreground color
-				}
-				else
+				} else
 				{
 					this.animatedObjects.addRectangleObject(parseInt(nextCommand[1]), // ID
 															nextCommand[2], // Label
@@ -702,24 +686,38 @@ function AnimationManager(objectManager)
 					this.animatedObjects.setNodePosition(parseInt(nextCommand[1]), parseInt(nextCommand[5]), parseInt(nextCommand[6]));
 				}
 				undoBlock.push(new UndoCreate(parseInt(nextCommand[1])));
-			}
-			
-			else if (nextCommand[0].toUpperCase() == "MOVE")
-			{
-				var objectID = parseInt(nextCommand[1]);
-				var nextAnim =  new SingleAnimation(objectID, 
-													this.animatedObjects.getNodeX(objectID), 
-													this.animatedObjects.getNodeY(objectID), 
-													parseInt(nextCommand[2]),
-													parseInt(nextCommand[3]));
-				this.currentBlock.push(nextAnim);
+			} else if (nextCommand[0].toUpperCase() == "MOVE")
+                        {
+                                var objectID = parseInt(nextCommand[1]);
+                                var toX = parseInt(nextCommand[2]);
+                                var toY = parseInt(nextCommand[3]);
+                                var nextAnim =  new SingleAnimation(objectID,
+                                                                                                        this.animatedObjects.getNodeX(objectID),
+                                                                                                        this.animatedObjects.getNodeY(objectID),
+                                                                                                        toX,
+                                                                                                        toY);
+                                this.currentBlock.push(nextAnim);
 
-				undoBlock.push(new UndoMove(nextAnim.objectID, nextAnim.toX, nextAnim.toY, nextAnim.fromX, nextAnim.fromY));
+                                undoBlock.push(new UndoMove(nextAnim.objectID, nextAnim.toX, nextAnim.toY, nextAnim.fromX, nextAnim.fromY));
 
-				anyAnimations = true;
-			}
-			
-			else if (nextCommand[0].toUpperCase() == "MOVETOALIGNRIGHT")
+                                anyAnimations = true;
+                        } else if (nextCommand[0].toUpperCase() == "MOVEALONGCURVE")
+                        {
+                                var curveObjectID = parseInt(nextCommand[1]);
+                                var controlX = parseInt(nextCommand[2]);
+                                var controlY = parseInt(nextCommand[3]);
+                                var curveToX = parseInt(nextCommand[4]);
+                                var curveToY = parseInt(nextCommand[5]);
+                                var curveAnim = new SingleAnimation(curveObjectID,
+                                                                                                        this.animatedObjects.getNodeX(curveObjectID),
+                                                                                                        this.animatedObjects.getNodeY(curveObjectID),
+                                                                                                        curveToX,
+                                                                                                        curveToY,
+                                                                                                        { type: "quadratic", controlX: controlX, controlY: controlY });
+                                this.currentBlock.push(curveAnim);
+                                undoBlock.push(new UndoMove(curveAnim.objectID, curveAnim.toX, curveAnim.toY, curveAnim.fromX, curveAnim.fromY));
+                                anyAnimations = true;
+                        } else if (nextCommand[0].toUpperCase() == "MOVETOALIGNRIGHT")
 			{
 				var id = parseInt(nextCommand[1]);
 				var otherId = parseInt(nextCommand[2]);
@@ -734,47 +732,45 @@ function AnimationManager(objectManager)
 				this.currentBlock.push(nextAnim);
 				undoBlock.push(new UndoMove(nextAnim.objectID, nextAnim.toX, nextAnim.toY, nextAnim.fromX, nextAnim.fromY));
 				anyAnimations = true;
-			}
-
-			else if (nextCommand[0].toUpperCase() == "STEP")
+			} else if (nextCommand[0].toUpperCase() == "STEP")
 			{
 				foundBreak = true;
-			}
-			else if (nextCommand[0].toUpperCase() == "SETFOREGROUNDCOLOR")
+			} else if (nextCommand[0].toUpperCase() == "SETFOREGROUNDCOLOR")
 			{
 				var id = parseInt(nextCommand[1]);
 				var oldColor = this.animatedObjects.foregroundColor(id);
 				this.animatedObjects.setForegroundColor(id, this.parseColor(nextCommand[2]));
 				undoBlock.push(new UndoSetForegroundColor(id, oldColor));
-			}
-			else if (nextCommand[0].toUpperCase() == "SETBACKGROUNDCOLOR")
-			{
-				id = parseInt(nextCommand[1]);
-				oldColor = this.animatedObjects.backgroundColor(id);
-				this.animatedObjects.setBackgroundColor(id, this.parseColor(nextCommand[2]));
-				undoBlock.push(new UndoSetBackgroundColor(id, oldColor));
-			}
-			else if (nextCommand[0].toUpperCase() == "SETHIGHLIGHT")
-			{
-				var newHighlight = this.parseBool(nextCommand[2]);
-				this.animatedObjects.setHighlight( parseInt(nextCommand[1]), newHighlight);
-				undoBlock.push(new UndoHighlight( parseInt(nextCommand[1]), !newHighlight));
-			}
-			else if (nextCommand[0].toUpperCase() == "DISCONNECT")
+                        } else if (nextCommand[0].toUpperCase() == "SETBACKGROUNDCOLOR")
+                        {
+                                id = parseInt(nextCommand[1]);
+                                oldColor = this.animatedObjects.backgroundColor(id);
+                                this.animatedObjects.setBackgroundColor(id, this.parseColor(nextCommand[2]));
+                                undoBlock.push(new UndoSetBackgroundColor(id, oldColor));
+                        } else if (nextCommand[0].toUpperCase() == "SETRECTANGLELINETHICKNESS")
+                        {
+                                id = parseInt(nextCommand[1]);
+                                var newThickness = parseFloat(nextCommand[2]);
+                                var oldThickness = this.animatedObjects.setRectangleLineThickness(id, newThickness);
+                                undoBlock.push(new UndoSetRectangleLineThickness(id, oldThickness));
+                        } else if (nextCommand[0].toUpperCase() == "SETHIGHLIGHT")
+                        {
+                                var newHighlight = this.parseBool(nextCommand[2]);
+                                this.animatedObjects.setHighlight( parseInt(nextCommand[1]), newHighlight);
+                                undoBlock.push(new UndoHighlight( parseInt(nextCommand[1]), !newHighlight));
+			} else if (nextCommand[0].toUpperCase() == "DISCONNECT")
 			{
 				var undoConnect = this.animatedObjects.disconnect(parseInt(nextCommand[1]), parseInt(nextCommand[2]));
 				if (undoConnect != null)
 				{
 					undoBlock.push(undoConnect);
 				}
-			}
-			else if (nextCommand[0].toUpperCase() == "SETALPHA")
+			} else if (nextCommand[0].toUpperCase() == "SETALPHA")
 			{
 				var oldAlpha = this.animatedObjects.getAlpha(parseInt(nextCommand[1]));
 				this.animatedObjects.setAlpha(parseInt(nextCommand[1]), parseFloat(nextCommand[2]));
 				undoBlock.push(new UndoSetAlpha(parseInt(nextCommand[1]), oldAlpha));					
-			}
-                        else if (nextCommand[0].toUpperCase() == "SETTEXT")
+			} else if (nextCommand[0].toUpperCase() == "SETTEXT")
                         {
                                 if (nextCommand.length > 3)
                                 {
@@ -784,8 +780,7 @@ function AnimationManager(objectManager)
                                         {
                                                 undoBlock.push(new UndoSetText(parseInt(nextCommand[1]), oldText, parseInt(nextCommand[3]) ));
                                         }
-                                }
-                                else
+                                } else
                                 {
                                         oldText = this.animatedObjects.getText(parseInt(nextCommand[1]), 0);
                                         this.animatedObjects.setText(parseInt(nextCommand[1]), nextCommand[2], 0);
@@ -794,8 +789,7 @@ function AnimationManager(objectManager)
                                                 undoBlock.push(new UndoSetText(parseInt(nextCommand[1]), oldText, 0));
                                         }
                                 }
-                        }
-                        else if (nextCommand[0].toUpperCase() == "DELETE")
+                        } else if (nextCommand[0].toUpperCase() == "DELETE")
                         {
                                 var objectID  = parseInt(nextCommand[1]);
 				
@@ -811,14 +805,12 @@ function AnimationManager(objectManager)
 					undoBlock.push(obj.createUndoDelete());
 					this.animatedObjects.removeObject(objectID);
 				}
-			}
-                        else if (nextCommand[0].toUpperCase() == "CREATEHIGHLIGHTCIRCLE")
+			} else if (nextCommand[0].toUpperCase() == "CREATEHIGHLIGHTCIRCLE")
                         {
                                 if (nextCommand.length > 5)
                                 {
                                         this.animatedObjects.addHighlightCircleObject(parseInt(nextCommand[1]), this.parseColor(nextCommand[2]), parseFloat(nextCommand[5]));
-                                }
-                                else
+                                } else
                                 {
                                         this.animatedObjects.addHighlightCircleObject(parseInt(nextCommand[1]), this.parseColor(nextCommand[2]), 20);
                                 }
@@ -829,8 +821,7 @@ function AnimationManager(objectManager)
                                 undoBlock.push(new UndoCreate(parseInt(nextCommand[1])));
 
 
-                        }
-                        else if (nextCommand[0].toUpperCase() == "CREATEHIGHLIGHTOVAL")
+                        } else if (nextCommand[0].toUpperCase() == "CREATEHIGHLIGHTOVAL")
                         {
                                 this.animatedObjects.addHighlightOvalObject(
                                         parseInt(nextCommand[1]),
@@ -843,14 +834,12 @@ function AnimationManager(objectManager)
                                 undoBlock.push(new UndoCreate(parseInt(nextCommand[1])));
 
 
-                        }
-                        else if (nextCommand[0].toUpperCase() == "CREATELABEL")
+                        } else if (nextCommand[0].toUpperCase() == "CREATELABEL")
                         {
 				if (nextCommand.length == 6)
 				{
 					this.animatedObjects.addLabelObject(parseInt(nextCommand[1]), nextCommand[2], this.parseBool(nextCommand[5]));						
-				}
-				else
+				} else
 				{
 					this.animatedObjects.addLabelObject(parseInt(nextCommand[1]), nextCommand[2], true);
 				}
@@ -860,56 +849,52 @@ function AnimationManager(objectManager)
 					this.animatedObjects.setNodePosition(parseInt(nextCommand[1]), parseFloat(nextCommand[3]), parseFloat(nextCommand[4]));
 				}
 				undoBlock.push(new UndoCreate(parseInt(nextCommand[1])));
-			}
-			else if (nextCommand[0].toUpperCase() == "SETEDGECOLOR")
-			{
-				var from = parseInt(nextCommand[1]);
-				var to = parseInt(nextCommand[2]);
-				var newColor = this.parseColor(nextCommand[3]);
-				var oldColor = this.animatedObjects.setEdgeColor(from, to, newColor);				
-				undoBlock.push(new UndoSetEdgeColor(from, to, oldColor));
-			}
-			else if (nextCommand[0].toUpperCase() == "SETEDGEALPHA")
-			{
-				var from = parseInt(nextCommand[1]);
-				var to = parseInt(nextCommand[2]);
-				var newAlpha = parseFloat(nextCommand[3]);
+			} else if (nextCommand[0].toUpperCase() == "SETEDGECOLOR")
+                        {
+                                var from = parseInt(nextCommand[1]);
+                                var to = parseInt(nextCommand[2]);
+                                var newColor = this.parseColor(nextCommand[3]);
+                                var oldColor = this.animatedObjects.setEdgeColor(from, to, newColor);
+                                undoBlock.push(new UndoSetEdgeColor(from, to, oldColor));
+                        } else if (nextCommand[0].toUpperCase() == "SETEDGETHICKNESS")
+                        {
+                                var from = parseInt(nextCommand[1]);
+                                var to = parseInt(nextCommand[2]);
+                                var newThickness = parseFloat(nextCommand[3]);
+                                var oldThickness = this.animatedObjects.setEdgeThickness(from, to, newThickness);
+                                undoBlock.push(new UndoSetEdgeThickness(from, to, oldThickness));
+                        } else if (nextCommand[0].toUpperCase() == "SETEDGEALPHA")
+                        {
+                                var from = parseInt(nextCommand[1]);
+                                var to = parseInt(nextCommand[2]);
+                                var newAlpha = parseFloat(nextCommand[3]);
 				var oldAplpha = this.animatedObjects.setEdgeAlpha(from, to, newAlpha);				
 				undoBlock.push(new UndoSetEdgeAlpha(from, to, oldAplpha));
-			}
-			
-			
-			else if (nextCommand[0].toUpperCase() == "SETEDGEHIGHLIGHT")
+			} else if (nextCommand[0].toUpperCase() == "SETEDGEHIGHLIGHT")
 			{
 				var newHighlight = this.parseBool(nextCommand[3]);
 				var from = parseInt(nextCommand[1]);
 				var to = parseInt(nextCommand[2]);
 				var oldHighlight = this.animatedObjects.setEdgeHighlight(from, to, newHighlight);
 				undoBlock.push(new UndoHighlightEdge(from, to, oldHighlight));
-			}
-			else if (nextCommand[0].toUpperCase() == "SETHEIGHT")
+			} else if (nextCommand[0].toUpperCase() == "SETHEIGHT")
 			{
 				id = parseInt(nextCommand[1]);
 				var oldHeight = this.animatedObjects.getHeight(id);
 				this.animatedObjects.setHeight(id, parseInt(nextCommand[2]));
 				undoBlock.push(new UndoSetHeight(id, oldHeight));
-			}
-			else if (nextCommand[0].toUpperCase() == "SETLAYER")
+			} else if (nextCommand[0].toUpperCase() == "SETLAYER")
 			{
 				this.animatedObjects.setLayer(parseInt(nextCommand[1]), parseInt(nextCommand[2]));
 				//TODO: Add undo information here
-			}
-			
-			
-			else if (nextCommand[0].toUpperCase() == "CREATELINKEDLIST")
+			} else if (nextCommand[0].toUpperCase() == "CREATELINKEDLIST")
 			{
 				if (nextCommand.length == 11)
 				{
 					this.animatedObjects.addLinkedListObject(parseInt(nextCommand[1]), nextCommand[2], 
 			               parseInt(nextCommand[3]), parseInt(nextCommand[4]), parseFloat(nextCommand[7]), 
 			               this.parseBool(nextCommand[8]), this.parseBool(nextCommand[9]),parseInt(nextCommand[10]), "#FFFFFF", "#000000");
-				}
-				else
+				} else
 				{
 					this.animatedObjects.addLinkedListObject(parseInt(nextCommand[1]), nextCommand[2], parseInt(nextCommand[3]), parseInt(nextCommand[4]), 0.25, true, false, 1, "#FFFFFF", "#000000");
 				}
@@ -919,110 +904,89 @@ function AnimationManager(objectManager)
 					undoBlock.push(new UndoCreate(parseInt(nextCommand[1])));
 				}
 				
-			}
-			else if (nextCommand[0].toUpperCase() == "SETNULL")
+			} else if (nextCommand[0].toUpperCase() == "SETNULL")
 			{
 				var oldNull = this.animatedObjects.getNull(parseInt(nextCommand[1]));
 				this.animatedObjects.setNull(parseInt(nextCommand[1]), this.parseBool(nextCommand[2]));
 				undoBlock.push(new UndoSetNull(parseInt(nextCommand[1]), oldNull));					
-			}
-			else if (nextCommand[0].toUpperCase() == "SETTEXTCOLOR")
+			} else if (nextCommand[0].toUpperCase() == "SETTEXTCOLOR")
 			{
 				if (nextCommand.length > 3)
 				{
 					oldColor = this.animatedObjects.getTextColor(parseInt(nextCommand[1]), parseInt(nextCommand[3]));
 					this.animatedObjects.setTextColor(parseInt(nextCommand[1]), this.parseColor(nextCommand[2]), parseInt(nextCommand[3]));
 					undoBlock.push(new UndoSetTextColor(parseInt(nextCommand[1]), oldColor, parseInt(nextCommand[3]) ));					
-				}
-				else
+				} else
 				{
 					oldColor = this.animatedObjects.getTextColor(parseInt(nextCommand[1]), 0);
 					this.animatedObjects.setTextColor(parseInt(nextCommand[1]),this.parseColor(nextCommand[2]), 0);
 					undoBlock.push(new UndoSetTextColor(parseInt(nextCommand[1]), oldColor, 0));					
 				}
-			}
-			
-			
-			else if (nextCommand[0].toUpperCase() == "CREATEBTREENODE")
+			} else if (nextCommand[0].toUpperCase() == "CREATEBTREENODE")
 			{
 
 				this.animatedObjects.addBTreeNode(parseInt(nextCommand[1]), parseFloat(nextCommand[2]), parseFloat(nextCommand[3]), 
 			                 parseInt(nextCommand[4]),this.parseColor(nextCommand[7]), this.parseColor(nextCommand[8]));
 				this.animatedObjects.setNodePosition(parseInt(nextCommand[1]), parseInt(nextCommand[5]), parseInt(nextCommand[6]));
 				undoBlock.push(new UndoCreate(parseInt(nextCommand[1])));
-			}
-
-			else if (nextCommand[0].toUpperCase() == "SETWIDTH")
+			} else if (nextCommand[0].toUpperCase() == "SETWIDTH")
 			{
 				var id = parseInt(nextCommand[1]);
 				this.animatedObjects.setWidth(id, parseInt(nextCommand[2]));
 				var oldWidth = this.animatedObjects.getWidth(id);
 				undoBlock.push(new UndoSetWidth(id, oldWidth));
-			}
-			else if (nextCommand[0].toUpperCase() == "SETNUMELEMENTS")
+			} else if (nextCommand[0].toUpperCase() == "SETNUMELEMENTS")
 			{
 				var oldElem = this.animatedObjects.getObject(parseInt(nextCommand[1]));
 				undoBlock.push(new UndoSetNumElements(oldElem, parseInt(nextCommand[2])));
 				this.animatedObjects.setNumElements(parseInt(nextCommand[1]), parseInt(nextCommand[2]));
-			}
-			else if (nextCommand[0].toUpperCase() == "SETPOSITION")
+			} else if (nextCommand[0].toUpperCase() == "SETPOSITION")
 			{
 				var id = parseInt(nextCommand[1])
 				var oldX = this.animatedObjects.getNodeX(id);
 				var oldY = this.animatedObjects.getNodeY(id);
 				undoBlock.push(new UndoSetPosition(id, oldX, oldY));
 				this.animatedObjects.setNodePosition(id, parseInt(nextCommand[2]), parseInt(nextCommand[3]));
-			}
-			else if (nextCommand[0].toUpperCase() == "ALIGNRIGHT")
+			} else if (nextCommand[0].toUpperCase() == "ALIGNRIGHT")
 			{
 				var id = parseInt(nextCommand[1])
 				var oldX = this.animatedObjects.getNodeX(id);
 				var oldY = this.animatedObjects.getNodeY(id);
-				undoBlock.push(new UndoSetPosition(id, oldX. oldY));
+				undoBlock.push(new UndoSetPosition(id, oldX, oldY));
 				this.animatedObjects.alignRight(id, parseInt(nextCommand[2]));
-			}
-			else if (nextCommand[0].toUpperCase() == "ALIGNLEFT")
+			} else if (nextCommand[0].toUpperCase() == "ALIGNLEFT")
 			{
 				var id = parseInt(nextCommand[1])
 				var oldX = this.animatedObjects.getNodeX(id);
 				var oldY = this.animatedObjects.getNodeY(id);
-				undoBlock.push(new UndoSetPosition(id, oldX. oldY));
+				undoBlock.push(new UndoSetPosition(id, oldX, oldY));
 				this.animatedObjects.alignLeft(id, parseInt(nextCommand[2]));
-			}
-			else if (nextCommand[0].toUpperCase() == "ALIGNTOP")
+			} else if (nextCommand[0].toUpperCase() == "ALIGNTOP")
 			{
 				var id = parseInt(nextCommand[1])
 				var oldX = this.animatedObjects.getNodeX(id);
 				var oldY = this.animatedObjects.getNodeY(id);
-				undoBlock.push(new UndoSetPosition(id, oldX. oldY));
+				undoBlock.push(new UndoSetPosition(id, oldX, oldY));
 				this.animatedObjects.alignTop(id, parseInt(nextCommand[2]));
-			}
-			else if (nextCommand[0].toUpperCase() == "ALIGNBOTTOM")
+			} else if (nextCommand[0].toUpperCase() == "ALIGNBOTTOM")
 			{
 				var id = parseInt(nextCommand[1])
 				var oldX = this.animatedObjects.getNodeX(id);
 				var oldY = this.animatedObjects.getNodeY(id);
-				undoBlock.push(new UndoSetPosition(id, oldX. oldY));
+				undoBlock.push(new UndoSetPosition(id, oldX, oldY));
 				this.animatedObjects.alignBottom(id, parseInt(nextCommand[2]));
-			}
-
-
-
-
-
-			else if (nextCommand[0].toUpperCase() == "SETHIGHLIGHTINDEX")
+			} else if (nextCommand[0].toUpperCase() == "SETHIGHLIGHTINDEX")
 			{
 				var id = parseInt(nextCommand[1]);
 				var index = parseInt(nextCommand[2]);
                                 var oldIndex = this.animatedObjects.getHighlightIndex(id)
 				undoBlock.push(new UndoSetHighlightIndex(id, oldIndex));
 				this.animatedObjects.setHighlightIndex(id,index);
-			}else if(nextCommand[0].toUpperCase() == "SETTEXTSTYLE") {	
+			} else if (nextCommand[0].toUpperCase() == "SETTEXTSTYLE") {	
 				var id = parseInt(nextCommand[1]);
 				var fontStyle = nextCommand[2];
 				this.animatedObjects.setTextStyle(id,fontStyle);
-			}
-			else
+			} else
 			{
 	//			throw "Unknown command: " + nextCommand[0];					
 			}
@@ -1057,8 +1021,7 @@ function AnimationManager(objectManager)
 		if (commands == undefined || commands.length == 0)
 		{
 			this.AnimationSteps = ["Step"];
-		}
-		else
+		} else
 		{
 			this.AnimationSteps = commands;
 		}
@@ -1089,8 +1052,7 @@ function AnimationManager(objectManager)
 			timer = setTimeout('timeout()', 30); 
 
 			
-		}
-		else if (!this.currentlyAnimating && this.animationPaused && this.undoAnimationStepIndices != null)
+		} else if (!this.currentlyAnimating && this.animationPaused && this.undoAnimationStepIndices != null)
 		{
 			this.fireEvent("AnimationStarted","NoData");
 			this.currentlyAnimating = true;
@@ -1326,27 +1288,37 @@ function AnimationManager(objectManager)
 		{
 			this.currFrame = this.currFrame + 1;
 			var i;
-			for (i = 0; i < this.currentBlock.length; i++)
-			{
-				if (this.currFrame == this.animationBlockLength || (this.currFrame == 1 && this.animationBlockLength == 0))
-				{
-					this.animatedObjects.setNodePosition(this.currentBlock[i].objectID,
-													     this.currentBlock[i].toX,
-													     this.currentBlock[i].toY);
-				}
-				else if (this.currFrame < this.animationBlockLength)
-				{
-					var objectID = this.currentBlock[i].objectID;
-					var percent = 1 / (this.animationBlockLength - this.currFrame);
-					var oldX = this.animatedObjects.getNodeX(objectID);
-					var oldY = this.animatedObjects.getNodeY(objectID);
-					var targetX = this.currentBlock[i].toX;
-					var targety  = this.currentBlock[i].toY;						
-					var newX = this.lerp(this.animatedObjects.getNodeX(objectID), this.currentBlock[i].toX, percent);
-					var newY = this.lerp(this.animatedObjects.getNodeY(objectID), this.currentBlock[i].toY, percent);
-					this.animatedObjects.setNodePosition(objectID, newX, newY);
-				}
-			}
+                        for (i = 0; i < this.currentBlock.length; i++)
+                        {
+                                var anim = this.currentBlock[i];
+                                if (anim.useQuadratic)
+                                {
+                                        var totalFrames = Math.max(1, this.animationBlockLength);
+                                        if (this.currFrame >= totalFrames)
+                                        {
+                                                this.animatedObjects.setNodePosition(anim.objectID, anim.toX, anim.toY);
+                                        } else
+                                        {
+                                                var t = this.currFrame / totalFrames;
+                                                var invT = 1 - t;
+                                                var quadX = invT * invT * anim.fromX + 2 * invT * t * anim.controlX + t * t * anim.toX;
+                                                var quadY = invT * invT * anim.fromY + 2 * invT * t * anim.controlY + t * t * anim.toY;
+                                                this.animatedObjects.setNodePosition(anim.objectID, quadX, quadY);
+                                        }
+                                } else if (this.currFrame == this.animationBlockLength || (this.currFrame == 1 && this.animationBlockLength == 0))
+                                {
+                                        this.animatedObjects.setNodePosition(anim.objectID,
+                                                                                                             anim.toX,
+                                                                                                             anim.toY);
+                                } else if (this.currFrame < this.animationBlockLength)
+                                {
+                                        var objectID = anim.objectID;
+                                        var percent = 1 / (this.animationBlockLength - this.currFrame);
+                                        var newX = this.lerp(this.animatedObjects.getNodeX(objectID), anim.toX, percent);
+                                        var newY = this.lerp(this.animatedObjects.getNodeY(objectID), anim.toY, percent);
+                                        this.animatedObjects.setNodePosition(objectID, newX, newY);
+                                }
+                        }
 			if (this.currFrame >= this.animationBlockLength)
 			{
 				if (this.doingUndo)
@@ -1357,16 +1329,14 @@ function AnimationManager(objectManager)
 						this.fireEvent("AnimationWaiting","NoData");
 					}
 
-				}
-				else
+				} else
 				{
 					if (this.animationPaused && (this.currentAnimation < this.AnimationSteps.length))
 					{
 						this.awaitingStep = true;
 						this.fireEvent("AnimationWaiting","NoData");
 						this.currentBlock = [];
-					}
-					else
+					} else
 					{
 						this.startNextBlock();
 					}
@@ -1385,11 +1355,23 @@ AnimationManager.prototype = new EventListener();
 AnimationManager.prototype.constructor = AnimationManager;
 
 				
-function SingleAnimation(id, fromX, fromY, toX, toY)
+function SingleAnimation(id, fromX, fromY, toX, toY, options)
 {
-	this.objectID = id;
-	this.fromX = fromX;
-	this.fromY = fromY;
-	this.toX = toX;
-	this.toY = toY;	
+        this.objectID = id;
+        this.fromX = fromX;
+        this.fromY = fromY;
+        this.toX = toX;
+        this.toY = toY;
+        this.useQuadratic = false;
+        this.controlX = 0;
+        this.controlY = 0;
+        if (options != null && options != undefined)
+        {
+                if (options.type === "quadratic")
+                {
+                        this.useQuadratic = true;
+                        this.controlX = options.controlX;
+                        this.controlY = options.controlY;
+                }
+        }
 }

--- a/AnimationLibrary/Line.js
+++ b/AnimationLibrary/Line.js
@@ -29,8 +29,8 @@
 //  pointers in linked lists, and so on. 
 
 
-var LINE_maxHeightDiff = 5;
-var LINE_minHeightDiff = 3;
+var LINE_maxHeightDiff = 12;
+var LINE_minHeightDiff = 8;
 var LINE_range= LINE_maxHeightDiff - LINE_minHeightDiff + 1;
 var LINE_highlightDiff = 3;
 
@@ -43,14 +43,16 @@ function Line(n1, n2, color, cv, d, weight, anchorIndex)
 	this.Node1 = n1;
 	this.Node2 = n2;
 	this.Dirty = false;
-	this.directed = d;
-	this.edgeColor = color;
-	this.edgeLabel = weight;
-	this.highlighted = false;
-	this.addedToScene = true;
-	this.anchorPoint = anchorIndex;
-	this.highlightDiff = 0;
-	this.curve = cv;
+        this.directed = d;
+        this.edgeColor = color;
+        this.edgeLabel = weight;
+        this.highlighted = false;
+        this.addedToScene = true;
+        this.anchorPoint = anchorIndex;
+        this.highlightDiff = 0;
+        this.highlightAlpha = 1.0;
+        this.curve = cv;
+        this.thickness = 1;
 
 	this.alpha = 1.0;
 	this.color = function color()
@@ -58,27 +60,44 @@ function Line(n1, n2, color, cv, d, weight, anchorIndex)
 		return this.edgeColor;   
 	}
 	   
-	this.setColor = function(newColor)
-	{
-		this.edgeColor = newColor;
-		Dirty = true;
-	}
+        this.setColor = function(newColor)
+        {
+                this.edgeColor = newColor;
+                Dirty = true;
+        }
+
+        this.setThickness = function(newThickness)
+        {
+                this.thickness = newThickness;
+                Dirty = true;
+        }
+
+        this.getThickness = function()
+        {
+                return this.thickness;
+        }
 	   
 	this.setHighlight = function(highlightVal)
 	{
 		this.highlighted = highlightVal;   
 	}
 		   
-	this.pulseHighlight = function(frameNum)
-	{
-	   if (this.highlighted)
-	   {
-		   var frameMod = frameNum / 14.0;
-		   var delta  = Math.abs((frameMod) % (2 * LINE_range  - 2) - LINE_range + 1)
-		   this.highlightDiff =  delta + LINE_minHeightDiff;
-		   Dirty = true;			   
-	   }
-	}
+        this.pulseHighlight = function(frameNum)
+        {
+           if (this.highlighted)
+           {
+                   var phase = Math.abs(Math.sin(frameNum / 12.0));
+                   this.highlightAlpha = 0.35 + 0.65 * phase;
+                   this.highlightDiff = this.thickness;
+                   Dirty = true;
+           }
+           else
+           {
+                   this.highlightAlpha = 1.0;
+                   this.highlightDiff = this.thickness;
+                   Dirty = true;
+           }
+        }
 	   
 	   
 	this.hasNode = function(n)
@@ -187,10 +206,15 @@ function Line(n1, n2, color, cv, d, weight, anchorIndex)
 		   }
 		   ctx.globalAlpha = this.alpha;
 
-			if (this.highlighted)
-				this.drawArrow(this.highlightDiff, "#FF0000", ctx);
-			this.drawArrow(1, this.edgeColor, ctx);
-	   }
+                        this.drawArrow(this.thickness, this.edgeColor, ctx);
+                        if (this.highlighted)
+                        {
+                                ctx.save();
+                                ctx.globalAlpha = ctx.globalAlpha * this.highlightAlpha;
+                                this.drawArrow(this.thickness, "#ff3b30", ctx);
+                                ctx.restore();
+                        }
+           }
 	   
 	   
 }

--- a/AnimationLibrary/ObjectManager.js
+++ b/AnimationLibrary/ObjectManager.js
@@ -325,20 +325,35 @@ function ObjectManager()
 	}
 	
 	
-	this.setForegroundColor = function(objectID, color)
-	{
-		if (this.Nodes[objectID] != null && this.Nodes[objectID] != undefined)
-		{
-			this.Nodes[objectID].setForegroundColor(color);
-			
-		}
-	}
-	
-	this.setBackgroundColor = function(objectID, color)
-	{
-		if (this.Nodes[objectID] != null)
-		{
-			this.Nodes[objectID].setBackgroundColor(color);
+        this.setForegroundColor = function(objectID, color)
+        {
+                if (this.Nodes[objectID] != null && this.Nodes[objectID] != undefined)
+                {
+                        this.Nodes[objectID].setForegroundColor(color);
+
+                }
+        }
+
+        this.setRectangleLineThickness = function(objectID, thickness)
+        {
+                if (this.Nodes[objectID] == null || this.Nodes[objectID] == undefined)
+                {
+                        return 1;
+                }
+                if (this.Nodes[objectID].setLineThickness == undefined)
+                {
+                        return 1;
+                }
+                var oldThickness = this.Nodes[objectID].getLineThickness();
+                this.Nodes[objectID].setLineThickness(thickness);
+                return oldThickness;
+        }
+
+        this.setBackgroundColor = function(objectID, color)
+        {
+                if (this.Nodes[objectID] != null)
+                {
+                        this.Nodes[objectID].setBackgroundColor(color);
 			
 		}
 	}
@@ -673,11 +688,11 @@ function ObjectManager()
 	
 	
 	
-	this.setEdgeColor = function(fromID, toID, color) // returns old color
-	{
-		var oldColor ="#000000";
-		if (this.Edges[fromID] != null &&
-			this.Edges[fromID] != undefined)
+        this.setEdgeColor = function(fromID, toID, color) // returns old color
+        {
+                var oldColor ="#000000";
+                if (this.Edges[fromID] != null &&
+                        this.Edges[fromID] != undefined)
 		{
 			var len = this.Edges[fromID].length;
 			for (var i = len - 1; i >= 0; i--)
@@ -690,9 +705,49 @@ function ObjectManager()
 					this.Edges[fromID][i].setColor(color);		
 				}
 			}
-		}	
-		return oldColor;
-	}		
+                }
+                return oldColor;
+        }
+
+        this.setEdgeThickness = function(fromID, toID, thickness)
+        {
+                var oldThickness = 1;
+                if (this.Edges[fromID] != null &&
+                        this.Edges[fromID] != undefined)
+                {
+                        var len = this.Edges[fromID].length;
+                        for (var i = len - 1; i >= 0; i--)
+                        {
+                                if (this.Edges[fromID][i] != null &&
+                                        this.Edges[fromID][i] != undefined &&
+                                        this.Edges[fromID][i].Node2 == this.Nodes[toID])
+                                {
+                                        oldThickness = this.Edges[fromID][i].getThickness();
+                                        this.Edges[fromID][i].setThickness(thickness);
+                                }
+                        }
+                }
+                return oldThickness;
+        }
+
+        this.getEdgeThickness = function(fromID, toID)
+        {
+                if (this.Edges[fromID] != null &&
+                        this.Edges[fromID] != undefined)
+                {
+                        var len = this.Edges[fromID].length;
+                        for (var i = len - 1; i >= 0; i--)
+                        {
+                                if (this.Edges[fromID][i] != null &&
+                                        this.Edges[fromID][i] != undefined &&
+                                        this.Edges[fromID][i].Node2 == this.Nodes[toID])
+                                {
+                                        return this.Edges[fromID][i].getThickness();
+                                }
+                        }
+                }
+                return -1;
+        }
 	
 	this.alignTop = function(id1, id2)
 	{

--- a/AnimationLibrary/UndoFunctions.js
+++ b/AnimationLibrary/UndoFunctions.js
@@ -248,7 +248,25 @@ UndoSetBackgroundColor.prototype.constructor = UndoSetBackgroundColor;
 
 UndoSetBackgroundColor.prototype.undoInitialStep =  function (world)
 {
-	world.setBackgroundColor(this.objectID, this.color);
+        world.setBackgroundColor(this.objectID, this.color);
+}
+
+////////////////////////////////////////////////////////////
+// UndoSetRectangleLineThickness
+////////////////////////////////////////////////////////////
+
+function UndoSetRectangleLineThickness(id, oldThickness)
+{
+        this.objectID = id;
+        this.thickness = oldThickness;
+}
+
+UndoSetRectangleLineThickness.prototype = new UndoBlock();
+UndoSetRectangleLineThickness.prototype.constructor = UndoSetRectangleLineThickness;
+
+UndoSetRectangleLineThickness.prototype.undoInitialStep = function(world)
+{
+        world.setRectangleLineThickness(this.objectID, this.thickness);
 }
 
 
@@ -372,7 +390,26 @@ UndoSetEdgeAlpha.prototype.constructor = UndoSetEdgeAlpha;
 
 UndoSetEdgeAlpha.prototype.undoInitialStep = function(world)
 {
-	world.setEdgeAlpha(this.fromID, this.toID, this.alpha);
+        world.setEdgeAlpha(this.fromID, this.toID, this.alpha);
+}
+
+////////////////////////////////////////////////////////////
+// UndoSetEdgeThickness
+////////////////////////////////////////////////////////////
+
+function UndoSetEdgeThickness(from, to, oldThickness)
+{
+        this.fromID = from;
+        this.toID = to;
+        this.thickness = oldThickness;
+}
+
+UndoSetEdgeThickness.prototype = new UndoBlock();
+UndoSetEdgeThickness.prototype.constructor = UndoSetEdgeThickness;
+
+UndoSetEdgeThickness.prototype.undoInitialStep = function(world)
+{
+        world.setEdgeThickness(this.fromID, this.toID, this.thickness);
 }
 
 ////////////////////////////////////////////////////////////

--- a/graphAlgorithms/DirectedDFS.js
+++ b/graphAlgorithms/DirectedDFS.js
@@ -8,11 +8,11 @@ DirectedDFS.prototype = new Algorithm();
 DirectedDFS.prototype.constructor = DirectedDFS;
 DirectedDFS.superclass = Algorithm.prototype;
 
-DirectedDFS.CANVAS_WIDTH = 720;
-DirectedDFS.CANVAS_HEIGHT = 1280;
+DirectedDFS.CANVAS_WIDTH = 900;
+DirectedDFS.CANVAS_HEIGHT = 1600;
 
 DirectedDFS.ROW1_HEIGHT = 240;
-DirectedDFS.ROW2_HEIGHT = 640;
+DirectedDFS.ROW2_HEIGHT = 760;
 DirectedDFS.ROW3_HEIGHT =
   DirectedDFS.CANVAS_HEIGHT - DirectedDFS.ROW1_HEIGHT - DirectedDFS.ROW2_HEIGHT;
 
@@ -24,17 +24,25 @@ DirectedDFS.ROW3_START_Y =
 DirectedDFS.TITLE_Y = DirectedDFS.ROW1_CENTER_Y - 40;
 DirectedDFS.START_INFO_Y = DirectedDFS.ROW1_CENTER_Y + 40;
 
-DirectedDFS.GRAPH_AREA_CENTER_X = 300;
+DirectedDFS.GRAPH_AREA_CENTER_X = 360;
 DirectedDFS.GRAPH_NODE_RADIUS = 22;
 DirectedDFS.GRAPH_NODE_COLOR = "#e3f2fd";
 DirectedDFS.GRAPH_NODE_BORDER = "#0b3954";
 DirectedDFS.GRAPH_NODE_TEXT = "#003049";
-DirectedDFS.GRAPH_NODE_VISITED_COLOR = "#b8f5b1";
+DirectedDFS.GRAPH_NODE_VISITED_COLOR = "#66bb6a";
+DirectedDFS.GRAPH_NODE_VISITED_TEXT_COLOR = "#0b3d1f";
 DirectedDFS.HIGHLIGHT_RADIUS = DirectedDFS.GRAPH_NODE_RADIUS;
 DirectedDFS.EDGE_COLOR = "#4a4e69";
-DirectedDFS.EDGE_HIGHLIGHT_COLOR = "#f77f00";
+DirectedDFS.EDGE_VISITED_COLOR = "#66bb6a";
+DirectedDFS.EDGE_THICKNESS = 3;
+DirectedDFS.EDGE_HIGHLIGHT_THICKNESS = DirectedDFS.EDGE_THICKNESS;
+DirectedDFS.BIDIRECTIONAL_CURVE = 0.35;
+DirectedDFS.BIDIRECTIONAL_EXTRA_OFFSET = 0.12;
+// Minimum curvature magnitude to keep opposite-direction edges visually parallel.
+DirectedDFS.MIN_PARALLEL_SEPARATION = 0.42;
+DirectedDFS.PARALLEL_EDGE_GAP = 0.18;
 
-DirectedDFS.ARRAY_BASE_X = 540;
+DirectedDFS.ARRAY_BASE_X = 720;
 DirectedDFS.ARRAY_COLUMN_SPACING = 80;
 DirectedDFS.ARRAY_TOP_Y = DirectedDFS.ROW2_START_Y + 90;
 DirectedDFS.ARRAY_CELL_HEIGHT = 52;
@@ -43,15 +51,35 @@ DirectedDFS.ARRAY_CELL_INNER_HEIGHT = 42;
 DirectedDFS.ARRAY_HEADER_HEIGHT = DirectedDFS.ARRAY_CELL_INNER_HEIGHT;
 DirectedDFS.ARRAY_RECT_COLOR = "#f1f1f6";
 DirectedDFS.ARRAY_RECT_BORDER = "#2b2d42";
+DirectedDFS.ARRAY_RECT_HIGHLIGHT_BORDER = "#d62828";
+DirectedDFS.ARRAY_RECT_BORDER_THICKNESS = 1;
+DirectedDFS.ARRAY_RECT_HIGHLIGHT_THICKNESS = 3;
 DirectedDFS.ARRAY_TEXT_COLOR = "#2b2d42";
-DirectedDFS.ARRAY_VISITED_FILL = "#90ee90";
+DirectedDFS.ARRAY_VISITED_FILL = "#b3e5fc";
 DirectedDFS.ARRAY_HEADER_GAP = 20;
+DirectedDFS.BOTTOM_SECTION_GAP = 56;
+DirectedDFS.CODE_TOP_PADDING = 12;
 
-DirectedDFS.CODE_START_Y = DirectedDFS.ROW3_START_Y + 10;
+DirectedDFS.CODE_START_X = 120;
 DirectedDFS.CODE_LINE_HEIGHT = 32;
 DirectedDFS.CODE_STANDARD_COLOR = "#1d3557";
 DirectedDFS.CODE_HIGHLIGHT_COLOR = "#e63946";
 DirectedDFS.CODE_FONT = "bold 22";
+
+DirectedDFS.RECURSION_AREA_CENTER_X = 660;
+DirectedDFS.RECURSION_HEADER_HEIGHT = 44;
+DirectedDFS.RECURSION_LABEL_MARGIN = 14;
+DirectedDFS.RECURSION_AREA_BOTTOM_MARGIN = 30;
+DirectedDFS.RECURSION_FRAME_WIDTH = 320;
+DirectedDFS.RECURSION_FRAME_HEIGHT = 34;
+DirectedDFS.RECURSION_FRAME_MIN_HEIGHT = 22;
+DirectedDFS.RECURSION_FRAME_SPACING = 10;
+DirectedDFS.RECURSION_FRAME_MIN_SPACING = 6;
+DirectedDFS.RECURSION_RECT_COLOR = "#f8f9fa";
+DirectedDFS.RECURSION_RECT_BORDER = "#1d3557";
+DirectedDFS.RECURSION_RECT_ACTIVE_BORDER = "#e63946";
+DirectedDFS.RECURSION_TEXT_COLOR = "#1d3557";
+DirectedDFS.RECURSION_FONT = "bold 18";
 
 DirectedDFS.TITLE_COLOR = "#1d3557";
 DirectedDFS.START_INFO_COLOR = "#264653";
@@ -66,7 +94,33 @@ DirectedDFS.CODE_LINES = [
   ["            dfs(v);"],
   ["        }"],
   ["    }"],
-  ["}"],
+  ["}"]
+];
+
+DirectedDFS.TEMPLATE_ALLOWED = [
+  [false, true, true, false, true, false, false, true, false, false],
+  [true, false, true, false, true, true, false, false, false, false],
+  [true, true, false, true, false, true, true, false, false, false],
+  [false, false, true, false, false, false, true, false, false, false],
+  [true, true, false, false, false, true, false, true, true, false],
+  [false, true, true, false, true, false, true, false, true, true],
+  [false, false, true, true, false, true, false, false, false, true],
+  [true, false, false, false, true, false, false, false, true, false],
+  [false, false, false, false, true, true, false, true, false, true],
+  [false, false, false, false, false, true, true, false, true, false]
+];
+
+DirectedDFS.EDGE_CURVES = [
+  [0, 0, -0.4, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0.4, 0, 0, 0, 0, -0.35, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0.35, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0.4],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 ];
 
 DirectedDFS.prototype.init = function (am, w, h) {
@@ -78,6 +132,10 @@ DirectedDFS.prototype.init = function (am, w, h) {
   this.vertexLabels = [];
   this.vertexPositions = [];
   this.adjacencyList = [];
+  this.edgePairs = [];
+  this.edgeStates = {};
+  this.edgeMeta = {};
+  this.edgeCurveOverrides = {};
   this.vertexIDs = [];
   this.visitedRectIDs = [];
   this.parentRectIDs = [];
@@ -86,6 +144,13 @@ DirectedDFS.prototype.init = function (am, w, h) {
   this.highlightCircleID = -1;
   this.currentCodeLine = -1;
   this.startDisplayID = -1;
+  this.recursionBackgroundID = -1;
+  this.recursionHeaderID = -1;
+  this.recursionFrameIDs = [];
+  this.activeRecursionIndex = -1;
+  this.recursionDepth = 0;
+  this.bottomSectionTopY =
+    DirectedDFS.ROW3_START_Y + DirectedDFS.CODE_TOP_PADDING;
 
   this.visited = [];
   this.parents = [];
@@ -136,48 +201,20 @@ DirectedDFS.prototype.reset = function () {
 DirectedDFS.prototype.setup = function () {
   this.commands = [];
 
-  this.vertexLabels = [
-    "A",
-    "B",
-    "C",
-    "D",
-    "E",
-    "F",
-    "G",
-    "H",
-    "I",
-    "J",
-  ];
-  this.vertexPositions = [
-    { x: 190, y: DirectedDFS.ROW2_START_Y + 90 },
-    { x: 310, y: DirectedDFS.ROW2_START_Y + 90 },
-    { x: 120, y: DirectedDFS.ROW2_START_Y + 230 },
-    { x: 260, y: DirectedDFS.ROW2_START_Y + 220 },
-    { x: 360, y: DirectedDFS.ROW2_START_Y + 230 },
-    { x: 120, y: DirectedDFS.ROW2_START_Y + 360 },
-    { x: 240, y: DirectedDFS.ROW2_START_Y + 360 },
-    { x: 360, y: DirectedDFS.ROW2_START_Y + 360 },
-    { x: 190, y: DirectedDFS.ROW2_START_Y + 500 },
-    { x: 310, y: DirectedDFS.ROW2_START_Y + 500 },
-  ];
+  this.edgePairs = [];
+  this.edgeStates = {};
+  this.edgeMeta = {};
+  this.edgeCurveOverrides = {};
 
-  this.adjacencyList = [
-    [1, 2],
-    [3, 4],
-    [5, 6],
-    [7],
-    [7, 8],
-    [8],
-    [8, 9],
-    [9],
-    [],
-    [],
-  ];
+  var vertexCount = 10;
+  this.vertexLabels = this.createVertexLabels(vertexCount);
+  this.generateRandomGraph(vertexCount);
 
   this.createTitleRow();
   this.createGraphArea();
   this.createArrayArea();
   this.createCodeDisplay();
+  this.createRecursionArea();
 
   this.highlightCodeLine(-1);
 
@@ -191,6 +228,422 @@ DirectedDFS.prototype.setup = function () {
 
 DirectedDFS.prototype.resetCallback = function () {
   this.implementAction(this.reset.bind(this), 0);
+};
+
+DirectedDFS.prototype.createVertexLabels = function (count) {
+  var labels = [];
+  var limit = Math.min(count, 26);
+  for (var i = 0; i < limit; i++) {
+    labels.push(String.fromCharCode(65 + i));
+  }
+  return labels;
+};
+
+DirectedDFS.prototype.generateRandomGraph = function (vertexCount) {
+  this.vertexPositions = this.computeTemplateLayout(vertexCount);
+  this.adjacencyList = new Array(vertexCount);
+  this.edgeCurveOverrides = {};
+
+  var allowed = DirectedDFS.TEMPLATE_ALLOWED;
+
+  var shuffle = function (array) {
+    for (var idx = array.length - 1; idx > 0; idx--) {
+      var swap = Math.floor(Math.random() * (idx + 1));
+      var temp = array[idx];
+      array[idx] = array[swap];
+      array[swap] = temp;
+    }
+  };
+
+  var isDirectionAllowed = function (from, to) {
+    return allowed[from] && allowed[from][to];
+  };
+
+  var isPairAllowed = function (a, b) {
+    return isDirectionAllowed(a, b) || isDirectionAllowed(b, a);
+  };
+
+  var pairKey = function (a, b) {
+    return a < b ? a + "-" + b : b + "-" + a;
+  };
+
+  var baseEdges = [];
+  var usedPairs = {};
+
+  var tryAddBaseEdge = function (a, b) {
+    if (a === b) {
+      return false;
+    }
+    if (!isPairAllowed(a, b)) {
+      return false;
+    }
+    var key = pairKey(a, b);
+    if (usedPairs[key]) {
+      return false;
+    }
+    var min = Math.min(a, b);
+    var max = Math.max(a, b);
+    baseEdges.push({ u: min, v: max });
+    usedPairs[key] = true;
+    return true;
+  };
+
+  for (var v = 1; v < vertexCount; v++) {
+    var neighbors = [];
+    for (var u = 0; u < vertexCount; u++) {
+      if (u === v) {
+        continue;
+      }
+      if (isPairAllowed(v, u)) {
+        neighbors.push(u);
+      }
+    }
+    if (neighbors.length === 0) {
+      continue;
+    }
+    shuffle(neighbors);
+    for (var n = 0; n < neighbors.length; n++) {
+      if (tryAddBaseEdge(v, neighbors[n])) {
+        break;
+      }
+    }
+  }
+
+  var baseEdgePercent = 0.45;
+  for (var i = 0; i < vertexCount; i++) {
+    for (var j = i + 1; j < vertexCount; j++) {
+      if (!isPairAllowed(i, j)) {
+        continue;
+      }
+      if (usedPairs[pairKey(i, j)]) {
+        continue;
+      }
+      if (Math.random() <= baseEdgePercent) {
+        tryAddBaseEdge(i, j);
+      }
+    }
+  }
+
+  var directedEdges = [];
+  var directedMap = {};
+  var incidentEdges = new Array(vertexCount);
+  var outDegree = new Array(vertexCount);
+  for (var p = 0; p < vertexCount; p++) {
+    incidentEdges[p] = [];
+    outDegree[p] = 0;
+    this.adjacencyList[p] = [];
+  }
+
+  var baseRecords = new Array(baseEdges.length);
+  for (var b = 0; b < baseEdges.length; b++) {
+    var edge = baseEdges[b];
+    var forwardAllowed = isDirectionAllowed(edge.u, edge.v);
+    var backwardAllowed = isDirectionAllowed(edge.v, edge.u);
+    if (!forwardAllowed && !backwardAllowed) {
+      continue;
+    }
+    var from = edge.u;
+    var to = edge.v;
+    if (forwardAllowed && backwardAllowed) {
+      if (Math.random() < 0.5) {
+        from = edge.u;
+        to = edge.v;
+      } else {
+        from = edge.v;
+        to = edge.u;
+      }
+    } else if (forwardAllowed) {
+      from = edge.u;
+      to = edge.v;
+    } else {
+      from = edge.v;
+      to = edge.u;
+    }
+
+    var record = {
+      from: from,
+      to: to,
+      min: edge.u,
+      max: edge.v,
+      curve: 0
+    };
+    directedEdges.push(record);
+    baseRecords[b] = record;
+    directedMap[from + "->" + to] = true;
+    outDegree[from]++;
+    incidentEdges[edge.u].push(b);
+    incidentEdges[edge.v].push(b);
+  }
+
+  for (var vertex = 0; vertex < vertexCount; vertex++) {
+    if (outDegree[vertex] === 0 && incidentEdges[vertex].length > 0) {
+      var options = incidentEdges[vertex].slice();
+      shuffle(options);
+      for (var opt = 0; opt < options.length && outDegree[vertex] === 0; opt++) {
+        var idx = options[opt];
+        var record = baseRecords[idx];
+        if (!record) {
+          continue;
+        }
+        var other = record.min === vertex ? record.max : record.min;
+        if (!isDirectionAllowed(vertex, other)) {
+          continue;
+        }
+        var newKey = vertex + "->" + other;
+        if (directedMap[newKey]) {
+          continue;
+        }
+        var oldKey = record.from + "->" + record.to;
+        delete directedMap[oldKey];
+        outDegree[record.from]--;
+        record.from = vertex;
+        record.to = other;
+        directedMap[newKey] = true;
+        outDegree[vertex]++;
+      }
+    }
+  }
+
+  for (var ensure = 0; ensure < vertexCount; ensure++) {
+    if (outDegree[ensure] === 0) {
+      var extraNeighbors = [];
+      if (allowed[ensure]) {
+        for (var target = 0; target < vertexCount; target++) {
+          if (target !== ensure && isDirectionAllowed(ensure, target)) {
+            extraNeighbors.push(target);
+          }
+        }
+      }
+      shuffle(extraNeighbors);
+      for (var en = 0; en < extraNeighbors.length; en++) {
+        var neighbor = extraNeighbors[en];
+        var ensureKey = ensure + "->" + neighbor;
+        if (directedMap[ensureKey]) {
+          continue;
+        }
+        directedEdges.push({
+          from: ensure,
+          to: neighbor,
+          min: Math.min(ensure, neighbor),
+          max: Math.max(ensure, neighbor),
+          curve: 0
+        });
+        directedMap[ensureKey] = true;
+        outDegree[ensure]++;
+        break;
+      }
+    }
+  }
+
+  var edgePercent = 0.35;
+  for (var from = 0; from < vertexCount; from++) {
+    if (!allowed[from]) {
+      continue;
+    }
+    for (var to = 0; to < vertexCount; to++) {
+      if (from === to || !allowed[from][to]) {
+        continue;
+      }
+      var key = from + "->" + to;
+      if (directedMap[key]) {
+        continue;
+      }
+      if (Math.random() <= edgePercent) {
+        directedEdges.push({
+          from: from,
+          to: to,
+          min: Math.min(from, to),
+          max: Math.max(from, to),
+          curve: 0
+        });
+        directedMap[key] = true;
+        outDegree[from]++;
+      }
+    }
+  }
+
+  var baseCurveForPair = function (min, max) {
+    if (
+      DirectedDFS.EDGE_CURVES[min] &&
+      typeof DirectedDFS.EDGE_CURVES[min][max] === "number"
+    ) {
+      return DirectedDFS.EDGE_CURVES[min][max];
+    }
+    return 0;
+  };
+
+  var hasCurveCandidate = false;
+  for (var d = 0; d < directedEdges.length; d++) {
+    var candidate = directedEdges[d];
+    if (Math.abs(baseCurveForPair(candidate.min, candidate.max)) > 0.01) {
+      hasCurveCandidate = true;
+      break;
+    }
+  }
+
+  if (!hasCurveCandidate) {
+    for (var a = 0; a < vertexCount && !hasCurveCandidate; a++) {
+      for (var c = a + 1; c < vertexCount && !hasCurveCandidate; c++) {
+        var baseCurve = baseCurveForPair(a, c);
+        if (Math.abs(baseCurve) < 0.01) {
+          continue;
+        }
+        if (isDirectionAllowed(a, c) && !directedMap[a + "->" + c]) {
+          directedEdges.push({
+            from: a,
+            to: c,
+            min: a,
+            max: c,
+            curve: 0
+          });
+          directedMap[a + "->" + c] = true;
+          hasCurveCandidate = true;
+        } else if (isDirectionAllowed(c, a) && !directedMap[c + "->" + a]) {
+          directedEdges.push({
+            from: c,
+            to: a,
+            min: a,
+            max: c,
+            curve: 0
+          });
+          directedMap[c + "->" + a] = true;
+          hasCurveCandidate = true;
+        }
+      }
+    }
+  }
+
+  var pairBuckets = {};
+  for (var edgeIndex = 0; edgeIndex < directedEdges.length; edgeIndex++) {
+    var entry = directedEdges[edgeIndex];
+    var bucketKey = entry.min + "-" + entry.max;
+    if (!pairBuckets[bucketKey]) {
+      pairBuckets[bucketKey] = {
+        edges: [],
+        min: entry.min,
+        max: entry.max
+      };
+    }
+    pairBuckets[bucketKey].edges.push(entry);
+  }
+
+  var hasCurveEdge = false;
+  var applyCurves = function (list, baseCurveValue, orientationSign) {
+    if (!list.length) {
+      return;
+    }
+    list[0].curve = baseCurveValue;
+    if (Math.abs(baseCurveValue) > 0.01) {
+      hasCurveEdge = true;
+    }
+    var baseSign;
+    if (Math.abs(baseCurveValue) > 0.01) {
+      baseSign = baseCurveValue >= 0 ? 1 : -1;
+    } else {
+      baseSign = orientationSign >= 0 ? 1 : -1;
+    }
+    for (var idx = 1; idx < list.length; idx++) {
+      var magnitude = Math.abs(baseCurveValue);
+      var offsetIndex;
+      if (magnitude < 0.01) {
+        magnitude = DirectedDFS.BIDIRECTIONAL_CURVE;
+        offsetIndex = idx - 1;
+      } else {
+        offsetIndex = idx;
+      }
+      var offset = DirectedDFS.BIDIRECTIONAL_EXTRA_OFFSET * offsetIndex;
+      var curveValue = baseSign * (magnitude + offset);
+      list[idx].curve = curveValue;
+      if (Math.abs(curveValue) > 0.01) {
+        hasCurveEdge = true;
+      }
+    }
+  };
+
+  for (var bucketKey in pairBuckets) {
+    if (!Object.prototype.hasOwnProperty.call(pairBuckets, bucketKey)) {
+      continue;
+    }
+    var bucket = pairBuckets[bucketKey];
+    var baseCurve = baseCurveForPair(bucket.min, bucket.max);
+    var forward = [];
+    var backward = [];
+    for (var bi = 0; bi < bucket.edges.length; bi++) {
+      var edgeRecord = bucket.edges[bi];
+      if (edgeRecord.from === bucket.min && edgeRecord.to === bucket.max) {
+        forward.push(edgeRecord);
+      } else {
+        backward.push(edgeRecord);
+      }
+    }
+
+    if (forward.length > 0 && backward.length > 0) {
+      var baseSign = 1;
+      if (Math.abs(baseCurve) > 0.01) {
+        baseSign = baseCurve >= 0 ? 1 : -1;
+      }
+      var minParallel = DirectedDFS.MIN_PARALLEL_SEPARATION;
+      var magnitude = Math.abs(baseCurve);
+      if (magnitude < minParallel) {
+        magnitude = minParallel;
+      }
+      if (magnitude < 0.01) {
+        magnitude = minParallel;
+      }
+      var forwardCurve = baseSign * magnitude;
+      var backwardCurve = baseSign * (magnitude + DirectedDFS.PARALLEL_EDGE_GAP);
+      applyCurves(forward, forwardCurve, baseSign);
+      applyCurves(backward, backwardCurve, baseSign);
+    } else if (forward.length > 0) {
+      var curveValue = Math.abs(baseCurve) < 0.01 ? 0 : baseCurve;
+      applyCurves(forward, curveValue, 1);
+    } else if (backward.length > 0) {
+      var reverseCurve = Math.abs(baseCurve) < 0.01 ? 0 : -baseCurve;
+      applyCurves(backward, reverseCurve, -1);
+    }
+  }
+
+  if (!hasCurveEdge && directedEdges.length > 0) {
+    var fallbackEdge = directedEdges[0];
+    fallbackEdge.curve =
+      fallbackEdge.from === fallbackEdge.min
+        ? DirectedDFS.BIDIRECTIONAL_CURVE
+        : -DirectedDFS.BIDIRECTIONAL_CURVE;
+  }
+
+  for (var listIndex = 0; listIndex < directedEdges.length; listIndex++) {
+    var finalEdge = directedEdges[listIndex];
+    this.adjacencyList[finalEdge.from].push(finalEdge.to);
+    this.edgeCurveOverrides[this.edgeKey(finalEdge.from, finalEdge.to)] =
+      finalEdge.curve;
+  }
+
+  for (var list = 0; list < this.adjacencyList.length; list++) {
+    shuffle(this.adjacencyList[list]);
+  }
+};
+
+DirectedDFS.prototype.computeTemplateLayout = function (vertexCount) {
+  var layout = [];
+  var baseX = 200;
+  var stepX = 130;
+  var baseY = DirectedDFS.ROW2_START_Y + 120;
+  var rowSpacing = 150;
+  var rowPattern = [4, 3, 4, 3, 4];
+
+  for (var row = 0, index = 0; row < rowPattern.length; row++) {
+    var count = rowPattern[row];
+    var startX = count === 4 ? baseX : baseX + stepX / 2;
+    var y = baseY + row * rowSpacing;
+    for (var col = 0; col < count && index < vertexCount; col++, index++) {
+      layout.push({ x: startX + col * stepX, y: y });
+    }
+    if (layout.length >= vertexCount) {
+      break;
+    }
+  }
+
+  return layout;
 };
 
 DirectedDFS.prototype.createTitleRow = function () {
@@ -244,15 +697,32 @@ DirectedDFS.prototype.createGraphArea = function () {
   for (var from = 0; from < this.adjacencyList.length; from++) {
     for (var j = 0; j < this.adjacencyList[from].length; j++) {
       var to = this.adjacencyList[from][j];
-      this.edgePairs.push({ from: from, to: to });
+      var curve = this.getEdgeCurve(from, to);
+      var pair = { from: from, to: to, curve: curve };
+      var key = this.edgeKey(from, to);
+      this.edgePairs.push(pair);
+      this.edgeStates[key] = { tree: false };
+      this.edgeMeta[key] = pair;
       this.cmd(
         "Connect",
         this.vertexIDs[from],
         this.vertexIDs[to],
         DirectedDFS.EDGE_COLOR,
-        0,
+        curve,
         1,
         ""
+      );
+      this.cmd(
+        "SetEdgeThickness",
+        this.vertexIDs[from],
+        this.vertexIDs[to],
+        DirectedDFS.EDGE_THICKNESS
+      );
+      this.cmd(
+        "SetEdgeHighlight",
+        this.vertexIDs[from],
+        this.vertexIDs[to],
+        0
       );
     }
   }
@@ -309,7 +779,7 @@ DirectedDFS.prototype.createArrayArea = function () {
       "CreateLabel",
       vertexLabelID,
       this.vertexLabels[i],
-      DirectedDFS.ARRAY_BASE_X - 95,
+      DirectedDFS.ARRAY_BASE_X - 58,
       rowY,
       0
     );
@@ -330,6 +800,11 @@ DirectedDFS.prototype.createArrayArea = function () {
     this.cmd("SetForegroundColor", visitedID, DirectedDFS.ARRAY_RECT_BORDER);
     this.cmd("SetBackgroundColor", visitedID, DirectedDFS.ARRAY_RECT_COLOR);
     this.cmd("SetTextColor", visitedID, DirectedDFS.ARRAY_TEXT_COLOR);
+    this.cmd(
+      "SetRectangleLineThickness",
+      visitedID,
+      DirectedDFS.ARRAY_RECT_BORDER_THICKNESS
+    );
 
     var parentID = this.nextIndex++;
     this.parentRectIDs[i] = parentID;
@@ -346,14 +821,39 @@ DirectedDFS.prototype.createArrayArea = function () {
     this.cmd("SetBackgroundColor", parentID, DirectedDFS.ARRAY_RECT_COLOR);
     this.cmd("SetTextColor", parentID, DirectedDFS.ARRAY_TEXT_COLOR);
   }
+
+  var lastRowIndex = this.vertexLabels.length - 1;
+  if (lastRowIndex >= 0) {
+    var lastCenterY =
+      DirectedDFS.ARRAY_TOP_Y + lastRowIndex * DirectedDFS.ARRAY_CELL_HEIGHT;
+    var arrayBottomY =
+      lastCenterY + DirectedDFS.ARRAY_CELL_INNER_HEIGHT / 2;
+    this.bottomSectionTopY =
+      arrayBottomY + DirectedDFS.BOTTOM_SECTION_GAP;
+  }
+};
+
+DirectedDFS.prototype.setVisitedCellHighlight = function (index, active) {
+  if (index < 0 || index >= this.visitedRectIDs.length) {
+    return;
+  }
+  var color = active
+    ? DirectedDFS.ARRAY_RECT_HIGHLIGHT_BORDER
+    : DirectedDFS.ARRAY_RECT_BORDER;
+  var thickness = active
+    ? DirectedDFS.ARRAY_RECT_HIGHLIGHT_THICKNESS
+    : DirectedDFS.ARRAY_RECT_BORDER_THICKNESS;
+  var rectID = this.visitedRectIDs[index];
+  this.cmd("SetForegroundColor", rectID, color);
+  this.cmd("SetRectangleLineThickness", rectID, thickness);
 };
 
 DirectedDFS.prototype.createCodeDisplay = function () {
-  var codeStartX = DirectedDFS.CANVAS_WIDTH / 2 - 150;
+  var startY = this.bottomSectionTopY + DirectedDFS.CODE_TOP_PADDING;
   this.codeID = this.addCodeToCanvasBase(
     DirectedDFS.CODE_LINES,
-    codeStartX,
-    DirectedDFS.CODE_START_Y,
+    DirectedDFS.CODE_START_X,
+    startY,
     DirectedDFS.CODE_LINE_HEIGHT,
     DirectedDFS.CODE_STANDARD_COLOR,
     0,
@@ -364,6 +864,200 @@ DirectedDFS.prototype.createCodeDisplay = function () {
     for (var j = 0; j < this.codeID[i].length; j++) {
       this.cmd("SetTextStyle", this.codeID[i][j], DirectedDFS.CODE_FONT);
     }
+  }
+};
+
+DirectedDFS.prototype.computeRecursionLayout = function (frameCount) {
+  var layout = {
+    height: DirectedDFS.RECURSION_FRAME_HEIGHT,
+    spacing: DirectedDFS.RECURSION_FRAME_SPACING,
+    startY:
+      this.bottomSectionTopY +
+      DirectedDFS.RECURSION_HEADER_HEIGHT +
+      DirectedDFS.RECURSION_LABEL_MARGIN +
+      DirectedDFS.RECURSION_FRAME_HEIGHT / 2
+  };
+
+  if (frameCount <= 0) {
+    return layout;
+  }
+
+  var availableHeight =
+    DirectedDFS.CANVAS_HEIGHT -
+    (this.bottomSectionTopY +
+      DirectedDFS.RECURSION_HEADER_HEIGHT +
+      DirectedDFS.RECURSION_LABEL_MARGIN +
+      DirectedDFS.RECURSION_AREA_BOTTOM_MARGIN);
+
+  if (availableHeight <= 0) {
+    return layout;
+  }
+
+  var spacing = frameCount === 1 ? 0 : layout.spacing;
+  var height = Math.min(
+    DirectedDFS.RECURSION_FRAME_HEIGHT,
+    Math.max(
+      DirectedDFS.RECURSION_FRAME_MIN_HEIGHT,
+      Math.floor(
+        (availableHeight - (frameCount - 1) * spacing) / Math.max(frameCount, 1)
+      )
+    )
+  );
+
+  var totalHeight = height * frameCount + spacing * (frameCount - 1);
+  if (totalHeight > availableHeight) {
+    spacing = Math.max(
+      DirectedDFS.RECURSION_FRAME_MIN_SPACING,
+      Math.floor(
+        (availableHeight - height * frameCount) / Math.max(1, frameCount - 1)
+      )
+    );
+    if (spacing < 0) {
+      spacing = 0;
+    }
+    height = Math.max(
+      DirectedDFS.RECURSION_FRAME_MIN_HEIGHT,
+      Math.floor(
+        (availableHeight - (frameCount - 1) * spacing) / Math.max(frameCount, 1)
+      )
+    );
+  }
+
+  layout.height = height;
+  layout.spacing = spacing;
+  layout.startY =
+    this.bottomSectionTopY +
+    DirectedDFS.RECURSION_HEADER_HEIGHT +
+    DirectedDFS.RECURSION_LABEL_MARGIN +
+    height / 2;
+
+  return layout;
+};
+
+DirectedDFS.prototype.createRecursionArea = function () {
+  var frameCount = this.vertexLabels.length;
+  var layout = this.computeRecursionLayout(frameCount);
+  var framesTop = layout.startY - layout.height / 2;
+  var totalFrameHeight =
+    frameCount > 0
+      ? layout.height * frameCount + layout.spacing * (frameCount - 1)
+      : 0;
+  this.recursionBackgroundID = -1;
+
+  this.recursionHeaderID = this.nextIndex++;
+  this.cmd(
+    "CreateLabel",
+    this.recursionHeaderID,
+    "Call Stack",
+    DirectedDFS.RECURSION_AREA_CENTER_X,
+    this.bottomSectionTopY + DirectedDFS.RECURSION_HEADER_HEIGHT / 2,
+    0
+  );
+  this.cmd(
+    "SetForegroundColor",
+    this.recursionHeaderID,
+    DirectedDFS.CODE_STANDARD_COLOR
+  );
+  this.cmd("SetTextStyle", this.recursionHeaderID, "bold 22");
+
+  this.recursionFrameIDs = [];
+  this.activeRecursionIndex = -1;
+  this.recursionDepth = 0;
+
+  var y = layout.startY;
+
+  for (var i = 0; i < frameCount; i++) {
+    var rectID = this.nextIndex++;
+    this.cmd(
+      "CreateRectangle",
+      rectID,
+      "",
+      DirectedDFS.RECURSION_FRAME_WIDTH,
+      layout.height,
+      DirectedDFS.RECURSION_AREA_CENTER_X,
+      y
+    );
+    this.cmd(
+      "SetBackgroundColor",
+      rectID,
+      DirectedDFS.RECURSION_RECT_COLOR
+    );
+    this.cmd("SetForegroundColor", rectID, DirectedDFS.RECURSION_RECT_BORDER);
+    this.cmd("SetAlpha", rectID, 0);
+    this.cmd("SetTextColor", rectID, DirectedDFS.RECURSION_TEXT_COLOR);
+    this.cmd("SetTextStyle", rectID, DirectedDFS.RECURSION_FONT);
+
+    this.recursionFrameIDs.push(rectID);
+
+    y += layout.height + layout.spacing;
+  }
+};
+
+DirectedDFS.prototype.resetRecursionArea = function () {
+  this.recursionDepth = 0;
+  this.activeRecursionIndex = -1;
+  for (var i = 0; i < this.recursionFrameIDs.length; i++) {
+    this.cmd("SetAlpha", this.recursionFrameIDs[i], 0);
+    this.cmd("SetText", this.recursionFrameIDs[i], "");
+    this.cmd(
+      "SetForegroundColor",
+      this.recursionFrameIDs[i],
+      DirectedDFS.RECURSION_RECT_BORDER
+    );
+  }
+};
+
+DirectedDFS.prototype.pushRecursionFrame = function (vertex, parent) {
+  if (
+    this.recursionDepth < 0 ||
+    this.recursionDepth >= this.recursionFrameIDs.length ||
+    !this.vertexLabels ||
+    vertex < 0 ||
+    vertex >= this.vertexLabels.length
+  ) {
+    return;
+  }
+
+  if (this.activeRecursionIndex >= 0 && this.activeRecursionIndex < this.recursionFrameIDs.length) {
+    this.cmd(
+      "SetForegroundColor",
+      this.recursionFrameIDs[this.activeRecursionIndex],
+      DirectedDFS.RECURSION_RECT_BORDER
+    );
+  }
+
+  var frameID = this.recursionFrameIDs[this.recursionDepth];
+  var text = "dfs(" + this.vertexLabels[vertex] + ")";
+  this.cmd("SetText", frameID, text);
+  this.cmd("SetAlpha", frameID, 1);
+  this.cmd(
+    "SetForegroundColor",
+    frameID,
+    DirectedDFS.RECURSION_RECT_ACTIVE_BORDER
+  );
+
+  this.activeRecursionIndex = this.recursionDepth;
+  this.recursionDepth++;
+};
+
+DirectedDFS.prototype.popRecursionFrame = function () {
+  if (this.recursionDepth <= 0) {
+    return;
+  }
+
+  this.recursionDepth--;
+  var frameID = this.recursionFrameIDs[this.recursionDepth];
+  this.cmd("SetAlpha", frameID, 0);
+  this.cmd("SetText", frameID, "");
+  this.cmd("SetForegroundColor", frameID, DirectedDFS.RECURSION_RECT_BORDER);
+
+  this.activeRecursionIndex = this.recursionDepth - 1;
+  if (this.activeRecursionIndex >= 0 && this.activeRecursionIndex < this.recursionFrameIDs.length) {
+    this.cmd(
+      "SetForegroundColor",
+      this.recursionFrameIDs[this.activeRecursionIndex],
+      DirectedDFS.RECURSION_RECT_ACTIVE_BORDER
+    );
   }
 };
 
@@ -393,40 +1087,243 @@ DirectedDFS.prototype.clearTraversalState = function () {
     this.parents[i] = null;
     this.cmd("SetText", this.visitedRectIDs[i], "F");
     this.cmd("SetBackgroundColor", this.visitedRectIDs[i], DirectedDFS.ARRAY_RECT_COLOR);
+    this.cmd(
+      "SetForegroundColor",
+      this.visitedRectIDs[i],
+      DirectedDFS.ARRAY_RECT_BORDER
+    );
+    this.cmd(
+      "SetRectangleLineThickness",
+      this.visitedRectIDs[i],
+      DirectedDFS.ARRAY_RECT_BORDER_THICKNESS
+    );
+    this.cmd("SetTextColor", this.visitedRectIDs[i], DirectedDFS.ARRAY_TEXT_COLOR);
     this.cmd("SetText", this.parentRectIDs[i], "-");
     this.cmd(
       "SetBackgroundColor",
       this.vertexIDs[i],
       DirectedDFS.GRAPH_NODE_COLOR
     );
+    this.cmd(
+      "SetTextColor",
+      this.vertexIDs[i],
+      DirectedDFS.GRAPH_NODE_TEXT
+    );
   }
+  this.resetEdgeStates();
   this.clearEdgeHighlights();
+  this.resetRecursionArea();
 };
 
 DirectedDFS.prototype.clearEdgeHighlights = function () {
+  if (!this.edgePairs) {
+    return;
+  }
   for (var i = 0; i < this.edgePairs.length; i++) {
     var edge = this.edgePairs[i];
+    this.highlightEdge(edge.from, edge.to, false);
+  }
+};
+
+DirectedDFS.prototype.edgeKey = function (from, to) {
+  return from + "->" + to;
+};
+
+DirectedDFS.prototype.getEdgeCurve = function (from, to) {
+  var key = this.edgeKey(from, to);
+  if (
+    this.edgeCurveOverrides &&
+    Object.prototype.hasOwnProperty.call(this.edgeCurveOverrides, key)
+  ) {
+    return this.edgeCurveOverrides[key];
+  }
+  if (
+    DirectedDFS.EDGE_CURVES[from] &&
+    typeof DirectedDFS.EDGE_CURVES[from][to] === "number"
+  ) {
+    return DirectedDFS.EDGE_CURVES[from][to];
+  }
+  return 0;
+};
+
+DirectedDFS.prototype.updateEdgeBaseColor = function (from, to) {
+  if (
+    !this.vertexIDs ||
+    from < 0 ||
+    to < 0 ||
+    from >= this.vertexIDs.length ||
+    to >= this.vertexIDs.length
+  ) {
+    return;
+  }
+  var key = this.edgeKey(from, to);
+  var baseColor = DirectedDFS.EDGE_COLOR;
+  if (this.edgeStates[key] && this.edgeStates[key].tree) {
+    baseColor = DirectedDFS.EDGE_VISITED_COLOR;
+  }
+  this.cmd("SetEdgeColor", this.vertexIDs[from], this.vertexIDs[to], baseColor);
+};
+
+DirectedDFS.prototype.setEdgeTreeState = function (from, to, isTree) {
+  var key = this.edgeKey(from, to);
+  if (!this.edgeStates[key]) {
+    this.edgeStates[key] = {};
+  }
+  this.edgeStates[key].tree = isTree;
+  this.updateEdgeBaseColor(from, to);
+};
+
+DirectedDFS.prototype.resetEdgeStates = function () {
+  if (!this.edgePairs) {
+    return;
+  }
+  for (var i = 0; i < this.edgePairs.length; i++) {
+    var edge = this.edgePairs[i];
+    var key = this.edgeKey(edge.from, edge.to);
+    if (this.edgeStates[key]) {
+      this.edgeStates[key].tree = false;
+    } else {
+      this.edgeStates[key] = { tree: false };
+    }
+    this.updateEdgeBaseColor(edge.from, edge.to);
+    this.cmd(
+      "SetEdgeThickness",
+      this.vertexIDs[edge.from],
+      this.vertexIDs[edge.to],
+      DirectedDFS.EDGE_THICKNESS
+    );
     this.cmd(
       "SetEdgeHighlight",
       this.vertexIDs[edge.from],
       this.vertexIDs[edge.to],
       0
     );
-    this.cmd(
-      "SetEdgeColor",
-      this.vertexIDs[edge.from],
-      this.vertexIDs[edge.to],
-      DirectedDFS.EDGE_COLOR
-    );
   }
+};
+
+DirectedDFS.prototype.highlightEdge = function (from, to, active) {
+  if (
+    !this.vertexIDs ||
+    from < 0 ||
+    to < 0 ||
+    from >= this.vertexIDs.length ||
+    to >= this.vertexIDs.length
+  ) {
+    return;
+  }
+  var fromID = this.vertexIDs[from];
+  var toID = this.vertexIDs[to];
+  if (active) {
+    this.updateEdgeBaseColor(from, to);
+    this.cmd(
+      "SetEdgeThickness",
+      fromID,
+      toID,
+      DirectedDFS.EDGE_HIGHLIGHT_THICKNESS
+    );
+    this.cmd("SetEdgeHighlight", fromID, toID, 1);
+  } else {
+    this.cmd("SetEdgeHighlight", fromID, toID, 0);
+    this.cmd("SetEdgeThickness", fromID, toID, DirectedDFS.EDGE_THICKNESS);
+    this.updateEdgeBaseColor(from, to);
+  }
+};
+
+DirectedDFS.prototype.animateHighlightTraversal = function (
+  fromIndex,
+  toIndex,
+  preferKey
+) {
+  if (fromIndex === toIndex) {
+    return;
+  }
+
+  var startPos = this.vertexPositions[fromIndex];
+  var endPos = this.vertexPositions[toIndex];
+  if (!startPos || !endPos) {
+    return;
+  }
+  var curve = 0;
+  var hasCurve = false;
+
+  if (typeof preferKey === "string") {
+    var preferredMeta = this.edgeMeta[preferKey];
+    if (preferredMeta) {
+      curve = preferredMeta.curve;
+      if (
+        preferredMeta.from !== fromIndex ||
+        preferredMeta.to !== toIndex
+      ) {
+        curve = -curve;
+      }
+      hasCurve = true;
+    }
+  }
+
+  if (!hasCurve) {
+    var key = this.edgeKey(fromIndex, toIndex);
+    var meta = this.edgeMeta[key];
+    if (meta) {
+      curve = meta.curve;
+      hasCurve = true;
+    } else {
+      var reverseMeta = this.edgeMeta[this.edgeKey(toIndex, fromIndex)];
+      if (reverseMeta) {
+        curve = -reverseMeta.curve;
+        hasCurve = true;
+      }
+    }
+  }
+
+  if (Math.abs(curve) < 0.01) {
+    this.cmd("Move", this.highlightCircleID, Math.round(endPos.x), Math.round(endPos.y));
+    this.cmd("Step");
+    return;
+  }
+
+  var dx = endPos.x - startPos.x;
+  var dy = endPos.y - startPos.y;
+  var midX = (startPos.x + endPos.x) / 2;
+  var midY = (startPos.y + endPos.y) / 2;
+  var controlX = midX - dy * curve;
+  var controlY = midY + dx * curve;
+
+  this.cmd(
+    "MoveAlongCurve",
+    this.highlightCircleID,
+    Math.round(controlX),
+    Math.round(controlY),
+    Math.round(endPos.x),
+    Math.round(endPos.y)
+  );
+  this.cmd("Step");
+};
+
+DirectedDFS.prototype.cleanInputLabel = function (value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.replace(/^\s+/, "").replace(/\s+$/, "");
+};
+
+DirectedDFS.prototype.findVertexIndex = function (label) {
+  if (!this.vertexLabels) {
+    return -1;
+  }
+  for (var i = 0; i < this.vertexLabels.length; i++) {
+    if (this.vertexLabels[i] === label) {
+      return i;
+    }
+  }
+  return -1;
 };
 
 DirectedDFS.prototype.startCallback = function () {
   if (!this.startField) return;
-  var raw = this.startField.value.trim();
+  var raw = this.cleanInputLabel(this.startField.value);
   if (raw.length === 0) return;
   var label = raw[0].toUpperCase();
-  var index = this.vertexLabels.indexOf(label);
+  var index = this.findVertexIndex(label);
   if (index === -1) {
     return;
   }
@@ -451,7 +1348,7 @@ DirectedDFS.prototype.runTraversal = function (startIndex) {
   this.cmd("Move", this.highlightCircleID, startPos.x, startPos.y);
   this.cmd("Step");
 
-  this.dfsVisit(startIndex);
+  this.dfsVisit(startIndex, -1);
 
   this.highlightCodeLine(-1);
   this.cmd("SetAlpha", this.highlightCircleID, 0);
@@ -459,11 +1356,16 @@ DirectedDFS.prototype.runTraversal = function (startIndex) {
   return this.commands;
 };
 
-DirectedDFS.prototype.dfsVisit = function (u) {
+DirectedDFS.prototype.dfsVisit = function (u, parent) {
+  this.pushRecursionFrame(u, parent);
+  this.cmd("Step");
+
   this.highlightCodeLine(0);
   this.cmd("Step");
 
   this.highlightCodeLine(1);
+  this.setVisitedCellHighlight(u, true);
+  this.cmd("Step");
   if (!this.visited[u]) {
     this.visited[u] = true;
     this.cmd("SetText", this.visitedRectIDs[u], "T");
@@ -477,8 +1379,14 @@ DirectedDFS.prototype.dfsVisit = function (u) {
       this.vertexIDs[u],
       DirectedDFS.GRAPH_NODE_VISITED_COLOR
     );
+    this.cmd(
+      "SetTextColor",
+      this.vertexIDs[u],
+      DirectedDFS.GRAPH_NODE_VISITED_TEXT_COLOR
+    );
     this.cmd("Step");
   }
+  this.setVisitedCellHighlight(u, false);
 
   this.highlightCodeLine(2);
   this.cmd("Step");
@@ -487,18 +1395,10 @@ DirectedDFS.prototype.dfsVisit = function (u) {
   for (var i = 0; i < neighbors.length; i++) {
     var v = neighbors[i];
     this.highlightCodeLine(3);
-    this.cmd(
-      "SetEdgeHighlight",
-      this.vertexIDs[u],
-      this.vertexIDs[v],
-      1
-    );
-    this.cmd(
-      "SetEdgeColor",
-      this.vertexIDs[u],
-      this.vertexIDs[v],
-      DirectedDFS.EDGE_HIGHLIGHT_COLOR
-    );
+    this.highlightEdge(u, v, true);
+    this.cmd("Step");
+
+    this.setVisitedCellHighlight(v, true);
     this.cmd("Step");
 
     if (!this.visited[v]) {
@@ -509,43 +1409,23 @@ DirectedDFS.prototype.dfsVisit = function (u) {
         this.parentRectIDs[v],
         this.vertexLabels[u]
       );
+      this.setEdgeTreeState(u, v, true);
       this.cmd("Step");
 
       this.highlightCodeLine(5);
-      this.cmd(
-        "Move",
-        this.highlightCircleID,
-        this.vertexPositions[v].x,
-        this.vertexPositions[v].y
-      );
-      this.cmd("Step");
+      this.animateHighlightTraversal(u, v, this.edgeKey(u, v));
 
-      this.dfsVisit(v);
+      this.dfsVisit(v, u);
 
-      this.cmd(
-        "Move",
-        this.highlightCircleID,
-        this.vertexPositions[u].x,
-        this.vertexPositions[u].y
-      );
-      this.cmd("Step");
+      this.animateHighlightTraversal(v, u, this.edgeKey(u, v));
     }
+
+    this.setVisitedCellHighlight(v, false);
 
     this.highlightCodeLine(6);
     this.cmd("Step");
 
-    this.cmd(
-      "SetEdgeHighlight",
-      this.vertexIDs[u],
-      this.vertexIDs[v],
-      0
-    );
-    this.cmd(
-      "SetEdgeColor",
-      this.vertexIDs[u],
-      this.vertexIDs[v],
-      DirectedDFS.EDGE_COLOR
-    );
+    this.highlightEdge(u, v, false);
 
     this.highlightCodeLine(2);
     this.cmd("Step");
@@ -555,6 +1435,7 @@ DirectedDFS.prototype.dfsVisit = function (u) {
   this.cmd("Step");
   this.highlightCodeLine(8);
   this.cmd("Step");
+  this.popRecursionFrame();
 };
 
 DirectedDFS.prototype.disableUI = function () {

--- a/graphAlgorithms/UndirectedDFS.html
+++ b/graphAlgorithms/UndirectedDFS.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Directed DFS Visualization</title>
+    <title>Undirected DFS Visualization</title>
     <link rel="stylesheet" href="../visualizationPageStyle.css" />
     <link rel="stylesheet" href="../ThirdParty/jquery-ui-1.8.11.custom.css" />
     <script src="../ThirdParty/jquery-1.5.2.min.js"></script>
@@ -19,7 +19,7 @@
     <script type="text/javascript" src="../AnimationLibrary/ObjectManager.js"></script>
     <script type="text/javascript" src="../AnimationLibrary/AnimationMain.js"></script>
     <script type="text/javascript" src="../AlgorithmLibrary/Algorithm.js"></script>
-    <script type="text/javascript" src="DirectedDFS.js"></script>
+    <script type="text/javascript" src="UndirectedDFS.js"></script>
   </head>
   <body onload="init();" class="VisualizationMainPage">
     <div id="container">

--- a/graphAlgorithms/UndirectedDFS.js
+++ b/graphAlgorithms/UndirectedDFS.js
@@ -1,0 +1,1303 @@
+// Custom visualization for DFS traversal on an undirected graph with an expanded canvas.
+
+function UndirectedDFS(am, w, h) {
+  this.init(am, w, h);
+}
+
+UndirectedDFS.prototype = new Algorithm();
+UndirectedDFS.prototype.constructor = UndirectedDFS;
+UndirectedDFS.superclass = Algorithm.prototype;
+
+UndirectedDFS.CANVAS_WIDTH = 900;
+UndirectedDFS.CANVAS_HEIGHT = 1600;
+
+UndirectedDFS.ROW1_HEIGHT = 240;
+UndirectedDFS.ROW2_HEIGHT = 760;
+UndirectedDFS.ROW3_HEIGHT =
+  UndirectedDFS.CANVAS_HEIGHT - UndirectedDFS.ROW1_HEIGHT - UndirectedDFS.ROW2_HEIGHT;
+
+UndirectedDFS.ROW1_CENTER_Y = UndirectedDFS.ROW1_HEIGHT / 2;
+UndirectedDFS.ROW2_START_Y = UndirectedDFS.ROW1_HEIGHT;
+UndirectedDFS.ROW3_START_Y =
+  UndirectedDFS.ROW1_HEIGHT + UndirectedDFS.ROW2_HEIGHT;
+
+UndirectedDFS.TITLE_Y = UndirectedDFS.ROW1_CENTER_Y - 40;
+UndirectedDFS.START_INFO_Y = UndirectedDFS.ROW1_CENTER_Y + 40;
+
+UndirectedDFS.GRAPH_AREA_CENTER_X = 360;
+UndirectedDFS.GRAPH_NODE_RADIUS = 22;
+UndirectedDFS.GRAPH_NODE_COLOR = "#e3f2fd";
+UndirectedDFS.GRAPH_NODE_BORDER = "#0b3954";
+UndirectedDFS.GRAPH_NODE_TEXT = "#003049";
+UndirectedDFS.GRAPH_NODE_VISITED_COLOR = "#66bb6a";
+UndirectedDFS.GRAPH_NODE_VISITED_TEXT_COLOR = "#0b3d1f";
+UndirectedDFS.HIGHLIGHT_RADIUS = UndirectedDFS.GRAPH_NODE_RADIUS;
+UndirectedDFS.EDGE_COLOR = "#4a4e69";
+UndirectedDFS.EDGE_VISITED_COLOR = "#66bb6a";
+UndirectedDFS.EDGE_THICKNESS = 3;
+UndirectedDFS.EDGE_ACTIVE_THICKNESS = UndirectedDFS.EDGE_THICKNESS;
+UndirectedDFS.EDGE_TREE_THICKNESS = 6;
+
+UndirectedDFS.ARRAY_BASE_X = 720;
+UndirectedDFS.ARRAY_COLUMN_SPACING = 80;
+UndirectedDFS.ARRAY_TOP_Y = UndirectedDFS.ROW2_START_Y + 90;
+UndirectedDFS.ARRAY_CELL_HEIGHT = 52;
+UndirectedDFS.ARRAY_CELL_WIDTH = 60;
+UndirectedDFS.ARRAY_CELL_INNER_HEIGHT = 42;
+UndirectedDFS.ARRAY_HEADER_HEIGHT = UndirectedDFS.ARRAY_CELL_INNER_HEIGHT;
+UndirectedDFS.ARRAY_RECT_COLOR = "#f1f1f6";
+UndirectedDFS.ARRAY_RECT_BORDER = "#2b2d42";
+UndirectedDFS.ARRAY_RECT_HIGHLIGHT_BORDER = "#d62828";
+UndirectedDFS.ARRAY_RECT_BORDER_THICKNESS = 1;
+UndirectedDFS.ARRAY_RECT_HIGHLIGHT_THICKNESS = 3;
+UndirectedDFS.ARRAY_TEXT_COLOR = "#2b2d42";
+UndirectedDFS.ARRAY_VISITED_FILL = "#b3e5fc";
+UndirectedDFS.ARRAY_HEADER_GAP = 20;
+UndirectedDFS.BOTTOM_SECTION_GAP = 56;
+UndirectedDFS.CODE_TOP_PADDING = 12;
+
+UndirectedDFS.CODE_START_X = 120;
+UndirectedDFS.CODE_LINE_HEIGHT = 32;
+UndirectedDFS.CODE_STANDARD_COLOR = "#1d3557";
+UndirectedDFS.CODE_HIGHLIGHT_COLOR = "#e63946";
+UndirectedDFS.CODE_FONT = "bold 22";
+
+UndirectedDFS.RECURSION_AREA_CENTER_X = 660;
+UndirectedDFS.RECURSION_HEADER_HEIGHT = 44;
+UndirectedDFS.RECURSION_LABEL_MARGIN = 14;
+UndirectedDFS.RECURSION_AREA_BOTTOM_MARGIN = 30;
+UndirectedDFS.RECURSION_FRAME_WIDTH = 320;
+UndirectedDFS.RECURSION_FRAME_HEIGHT = 34;
+UndirectedDFS.RECURSION_FRAME_MIN_HEIGHT = 22;
+UndirectedDFS.RECURSION_FRAME_SPACING = 10;
+UndirectedDFS.RECURSION_FRAME_MIN_SPACING = 6;
+UndirectedDFS.RECURSION_RECT_COLOR = "#f8f9fa";
+UndirectedDFS.RECURSION_RECT_BORDER = "#1d3557";
+UndirectedDFS.RECURSION_RECT_ACTIVE_BORDER = "#e63946";
+UndirectedDFS.RECURSION_TEXT_COLOR = "#1d3557";
+UndirectedDFS.RECURSION_FONT = "bold 18";
+
+UndirectedDFS.TITLE_COLOR = "#1d3557";
+UndirectedDFS.START_INFO_COLOR = "#264653";
+UndirectedDFS.HIGHLIGHT_COLOR = "#ff3b30";
+
+UndirectedDFS.CODE_LINES = [
+  ["void dfs(int u, int parent) {"],
+  ["    visited[u] = true;"],
+  ["    for (int v : adj[u]) {"],
+  ["        if (v != parent && !visited[v]) {"],
+  ["            parent[v] = u;"],
+  ["            dfs(v, u);"],
+  ["        }"],
+  ["    }"],
+  ["}"]
+];
+
+// Allowed adjacency template derived from the DFS classroom visualization so
+// the undirected graph reuses its well-spaced layout without overlaps.
+UndirectedDFS.TEMPLATE_ALLOWED = [
+  [false, true, true, false, true, false, false, true, false, false],
+  [true, false, true, false, true, true, false, false, false, false],
+  [true, true, false, true, false, true, true, false, false, false],
+  [false, false, true, false, false, false, true, false, false, false],
+  [true, true, false, false, false, true, false, true, true, false],
+  [false, true, true, false, true, false, true, false, true, true],
+  [false, false, true, true, false, true, false, false, false, true],
+  [true, false, false, false, true, false, false, false, true, false],
+  [false, false, false, false, true, true, false, true, false, true],
+  [false, false, false, false, false, true, true, false, true, false]
+];
+
+// Matching curve data from the DFS classroom visualization template. Only
+// entries with a non-zero magnitude will render as curved edges.
+UndirectedDFS.TEMPLATE_CURVES = [
+  [0, 0, -0.4, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0.4, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+];
+
+UndirectedDFS.prototype.init = function (am, w, h) {
+  UndirectedDFS.superclass.init.call(this, am, w, h);
+
+  this.controls = [];
+  this.addControls();
+
+  this.vertexLabels = [];
+  this.vertexPositions = [];
+  this.adjacencyList = [];
+  this.edgePairs = [];
+  this.edgeOrientation = {};
+  this.edgeStates = {};
+  this.edgeMeta = {};
+  this.vertexIDs = [];
+  this.visitedRectIDs = [];
+  this.parentRectIDs = [];
+  this.vertexRowLabelIDs = [];
+  this.codeID = [];
+  this.highlightCircleID = -1;
+  this.currentCodeLine = -1;
+  this.startDisplayID = -1;
+  this.recursionBackgroundID = -1;
+  this.recursionHeaderID = -1;
+  this.recursionFrameIDs = [];
+  this.activeRecursionIndex = -1;
+  this.recursionDepth = 0;
+  this.bottomSectionTopY =
+    UndirectedDFS.ROW3_START_Y + UndirectedDFS.CODE_TOP_PADDING;
+
+  this.visited = [];
+  this.parents = [];
+
+  this.implementAction(this.reset.bind(this), 0);
+};
+
+UndirectedDFS.prototype.addControls = function () {
+  addLabelToAlgorithmBar("Start Vertex:");
+  this.startField = addControlToAlgorithmBar("Text", "A");
+  this.startField.size = 4;
+  this.startButton = addControlToAlgorithmBar("Button", "Run DFS");
+  this.startButton.onclick = this.startCallback.bind(this);
+  this.startField.onkeydown = this.returnSubmit(
+    this.startField,
+    this.startCallback.bind(this),
+    2,
+    false
+  );
+
+  this.newGraphButton = addControlToAlgorithmBar("Button", "New Graph");
+  this.newGraphButton.onclick = this.resetCallback.bind(this);
+
+  this.directedGraphButton = addControlToAlgorithmBar("Button", "Directed DFS");
+  this.directedGraphButton.onclick = function () {
+    window.location.href = "DirectedDFS.html";
+  };
+
+  this.controls.push(
+    this.startField,
+    this.startButton,
+    this.newGraphButton,
+    this.directedGraphButton
+  );
+};
+
+UndirectedDFS.prototype.reset = function () {
+  this.nextIndex = 0;
+  if (
+    typeof animationManager !== "undefined" &&
+    animationManager.animatedObjects
+  ) {
+    animationManager.animatedObjects.clearAllObjects();
+  }
+  return this.setup();
+};
+
+UndirectedDFS.prototype.setup = function () {
+  this.commands = [];
+
+  this.edgeOrientation = {};
+  this.edgeStates = {};
+  this.edgeMeta = {};
+
+  var vertexCount = this.chooseVertexCount();
+  this.vertexLabels = this.createVertexLabels(vertexCount);
+  this.generateRandomGraph(vertexCount);
+
+  this.adjacencyList = new Array(this.vertexLabels.length);
+  for (var i = 0; i < this.adjacencyList.length; i++) {
+    this.adjacencyList[i] = [];
+  }
+  for (var e = 0; e < this.edgePairs.length; e++) {
+    var edge = this.edgePairs[e];
+    this.adjacencyList[edge.u].push(edge.v);
+    this.adjacencyList[edge.v].push(edge.u);
+  }
+
+  this.createTitleRow();
+  this.createGraphArea();
+  this.createArrayArea();
+  this.createCodeDisplay();
+  this.createRecursionArea();
+
+  this.highlightCodeLine(-1);
+
+  if (this.startField) {
+    this.startField.value = this.vertexLabels[0];
+  }
+
+  this.cmd("Step");
+  return this.commands;
+};
+
+UndirectedDFS.prototype.resetCallback = function () {
+  this.implementAction(this.reset.bind(this), 0);
+};
+
+UndirectedDFS.prototype.chooseVertexCount = function () {
+  return 10;
+};
+
+UndirectedDFS.prototype.createVertexLabels = function (count) {
+  var labels = [];
+  for (var i = 0; i < count; i++) {
+    labels.push(String.fromCharCode("A".charCodeAt(0) + i));
+  }
+  return labels;
+};
+
+UndirectedDFS.prototype.createTitleRow = function () {
+  var titleID = this.nextIndex++;
+  this.cmd(
+    "CreateLabel",
+    titleID,
+    "DFS Traversal On Undirected Graph",
+    UndirectedDFS.CANVAS_WIDTH / 2,
+    UndirectedDFS.TITLE_Y,
+    1
+  );
+  this.cmd("SetTextStyle", titleID, "bold 34");
+  this.cmd("SetForegroundColor", titleID, UndirectedDFS.TITLE_COLOR);
+
+  this.startDisplayID = this.nextIndex++;
+  this.cmd(
+    "CreateLabel",
+    this.startDisplayID,
+    "Start Vertex: A",
+    UndirectedDFS.CANVAS_WIDTH / 2,
+    UndirectedDFS.START_INFO_Y,
+    1
+  );
+  this.cmd("SetTextStyle", this.startDisplayID, "bold 24");
+  this.cmd("SetForegroundColor", this.startDisplayID, UndirectedDFS.START_INFO_COLOR);
+};
+
+UndirectedDFS.prototype.createGraphArea = function () {
+  this.vertexIDs = new Array(this.vertexLabels.length);
+
+  for (var i = 0; i < this.vertexLabels.length; i++) {
+    var id = this.nextIndex++;
+    this.vertexIDs[i] = id;
+    var pos = this.vertexPositions[i];
+    this.cmd(
+      "CreateCircle",
+      id,
+      this.vertexLabels[i],
+      pos.x,
+      pos.y,
+      UndirectedDFS.GRAPH_NODE_RADIUS
+    );
+    this.cmd("SetBackgroundColor", id, UndirectedDFS.GRAPH_NODE_COLOR);
+    this.cmd("SetForegroundColor", id, UndirectedDFS.GRAPH_NODE_BORDER);
+    this.cmd("SetTextColor", id, UndirectedDFS.GRAPH_NODE_TEXT);
+    this.cmd("SetHighlight", id, 0);
+  }
+
+  for (var j = 0; j < this.edgePairs.length; j++) {
+    var pair = this.edgePairs[j];
+    var key = this.edgeKey(pair.u, pair.v);
+    this.edgeOrientation[key] = {
+      from: pair.u,
+      to: pair.v
+    };
+    this.edgeStates[key] = { tree: false };
+    this.edgeMeta[key] = pair;
+    this.cmd(
+      "Connect",
+      this.vertexIDs[pair.u],
+      this.vertexIDs[pair.v],
+      UndirectedDFS.EDGE_COLOR,
+      pair.curve,
+      0,
+      ""
+    );
+    this.cmd(
+      "SetEdgeThickness",
+      this.vertexIDs[pair.u],
+      this.vertexIDs[pair.v],
+      UndirectedDFS.EDGE_THICKNESS
+    );
+    this.cmd(
+      "SetEdgeHighlight",
+      this.vertexIDs[pair.u],
+      this.vertexIDs[pair.v],
+      0
+    );
+  }
+
+  this.highlightCircleID = this.nextIndex++;
+  var startPos = this.vertexPositions[0];
+  this.cmd(
+    "CreateHighlightCircle",
+    this.highlightCircleID,
+    UndirectedDFS.HIGHLIGHT_COLOR,
+    startPos.x,
+    startPos.y,
+    UndirectedDFS.HIGHLIGHT_RADIUS
+  );
+  this.cmd("SetAlpha", this.highlightCircleID, 0);
+};
+
+UndirectedDFS.prototype.createArrayArea = function () {
+  var visitedHeaderID = this.nextIndex++;
+  var parentHeaderID = this.nextIndex++;
+  var headerY =
+    UndirectedDFS.ARRAY_TOP_Y - UndirectedDFS.ARRAY_CELL_HEIGHT / 2 - UndirectedDFS.ARRAY_HEADER_GAP;
+
+  this.cmd(
+    "CreateLabel",
+    visitedHeaderID,
+    "Visited",
+    UndirectedDFS.ARRAY_BASE_X,
+    headerY
+  );
+  this.cmd("SetTextStyle", visitedHeaderID, "bold 20");
+  this.cmd("SetForegroundColor", visitedHeaderID, UndirectedDFS.CODE_STANDARD_COLOR);
+
+  this.cmd(
+    "CreateLabel",
+    parentHeaderID,
+    "Parent",
+    UndirectedDFS.ARRAY_BASE_X + UndirectedDFS.ARRAY_COLUMN_SPACING,
+    headerY
+  );
+  this.cmd("SetTextStyle", parentHeaderID, "bold 20");
+  this.cmd("SetForegroundColor", parentHeaderID, UndirectedDFS.CODE_STANDARD_COLOR);
+
+  this.visitedRectIDs = new Array(this.vertexLabels.length);
+  this.parentRectIDs = new Array(this.vertexLabels.length);
+  this.vertexRowLabelIDs = new Array(this.vertexLabels.length);
+
+  for (var i = 0; i < this.vertexLabels.length; i++) {
+    var rowY = UndirectedDFS.ARRAY_TOP_Y + i * UndirectedDFS.ARRAY_CELL_HEIGHT;
+
+    var vertexLabelID = this.nextIndex++;
+    this.vertexRowLabelIDs[i] = vertexLabelID;
+    this.cmd(
+      "CreateLabel",
+      vertexLabelID,
+      this.vertexLabels[i],
+      UndirectedDFS.ARRAY_BASE_X - 58,
+      rowY,
+      0
+    );
+    this.cmd("SetTextStyle", vertexLabelID, "bold 20");
+    this.cmd("SetForegroundColor", vertexLabelID, UndirectedDFS.START_INFO_COLOR);
+
+    var visitedID = this.nextIndex++;
+    this.visitedRectIDs[i] = visitedID;
+    this.cmd(
+      "CreateRectangle",
+      visitedID,
+      "F",
+      UndirectedDFS.ARRAY_CELL_WIDTH,
+      UndirectedDFS.ARRAY_CELL_INNER_HEIGHT,
+      UndirectedDFS.ARRAY_BASE_X,
+      rowY
+    );
+    this.cmd("SetForegroundColor", visitedID, UndirectedDFS.ARRAY_RECT_BORDER);
+    this.cmd("SetBackgroundColor", visitedID, UndirectedDFS.ARRAY_RECT_COLOR);
+    this.cmd("SetTextColor", visitedID, UndirectedDFS.ARRAY_TEXT_COLOR);
+    this.cmd(
+      "SetRectangleLineThickness",
+      visitedID,
+      UndirectedDFS.ARRAY_RECT_BORDER_THICKNESS
+    );
+
+    var parentID = this.nextIndex++;
+    this.parentRectIDs[i] = parentID;
+    this.cmd(
+      "CreateRectangle",
+      parentID,
+      "-",
+      UndirectedDFS.ARRAY_CELL_WIDTH,
+      UndirectedDFS.ARRAY_CELL_INNER_HEIGHT,
+      UndirectedDFS.ARRAY_BASE_X + UndirectedDFS.ARRAY_COLUMN_SPACING,
+      rowY
+    );
+    this.cmd("SetForegroundColor", parentID, UndirectedDFS.ARRAY_RECT_BORDER);
+    this.cmd("SetBackgroundColor", parentID, UndirectedDFS.ARRAY_RECT_COLOR);
+    this.cmd("SetTextColor", parentID, UndirectedDFS.ARRAY_TEXT_COLOR);
+  }
+
+  var lastRowIndex = this.vertexLabels.length - 1;
+  if (lastRowIndex >= 0) {
+    var lastCenterY =
+      UndirectedDFS.ARRAY_TOP_Y + lastRowIndex * UndirectedDFS.ARRAY_CELL_HEIGHT;
+    var arrayBottomY =
+      lastCenterY + UndirectedDFS.ARRAY_CELL_INNER_HEIGHT / 2;
+    this.bottomSectionTopY = arrayBottomY + UndirectedDFS.BOTTOM_SECTION_GAP;
+  }
+};
+
+UndirectedDFS.prototype.setVisitedCellHighlight = function (index, active) {
+  if (index < 0 || index >= this.visitedRectIDs.length) {
+    return;
+  }
+  var color = active
+    ? UndirectedDFS.ARRAY_RECT_HIGHLIGHT_BORDER
+    : UndirectedDFS.ARRAY_RECT_BORDER;
+  var thickness = active
+    ? UndirectedDFS.ARRAY_RECT_HIGHLIGHT_THICKNESS
+    : UndirectedDFS.ARRAY_RECT_BORDER_THICKNESS;
+  var rectID = this.visitedRectIDs[index];
+  this.cmd("SetForegroundColor", rectID, color);
+  this.cmd("SetRectangleLineThickness", rectID, thickness);
+};
+
+UndirectedDFS.prototype.createCodeDisplay = function () {
+  var startY = this.bottomSectionTopY + UndirectedDFS.CODE_TOP_PADDING;
+  this.codeID = this.addCodeToCanvasBase(
+    UndirectedDFS.CODE_LINES,
+    UndirectedDFS.CODE_START_X,
+    startY,
+    UndirectedDFS.CODE_LINE_HEIGHT,
+    UndirectedDFS.CODE_STANDARD_COLOR,
+    0,
+    0
+  );
+
+  for (var i = 0; i < this.codeID.length; i++) {
+    for (var j = 0; j < this.codeID[i].length; j++) {
+      this.cmd("SetTextStyle", this.codeID[i][j], UndirectedDFS.CODE_FONT);
+    }
+  }
+};
+
+UndirectedDFS.prototype.computeRecursionLayout = function (frameCount) {
+  var layout = {
+    height: UndirectedDFS.RECURSION_FRAME_HEIGHT,
+    spacing: UndirectedDFS.RECURSION_FRAME_SPACING,
+    startY:
+      this.bottomSectionTopY +
+      UndirectedDFS.RECURSION_HEADER_HEIGHT +
+      UndirectedDFS.RECURSION_LABEL_MARGIN +
+      UndirectedDFS.RECURSION_FRAME_HEIGHT / 2
+  };
+
+  if (frameCount <= 0) {
+    return layout;
+  }
+
+  var availableHeight =
+    UndirectedDFS.CANVAS_HEIGHT -
+    (this.bottomSectionTopY +
+      UndirectedDFS.RECURSION_HEADER_HEIGHT +
+      UndirectedDFS.RECURSION_LABEL_MARGIN +
+      UndirectedDFS.RECURSION_AREA_BOTTOM_MARGIN);
+
+  if (availableHeight <= 0) {
+    return layout;
+  }
+
+  var spacing = frameCount === 1 ? 0 : layout.spacing;
+  var height = Math.min(
+    UndirectedDFS.RECURSION_FRAME_HEIGHT,
+    Math.max(
+      UndirectedDFS.RECURSION_FRAME_MIN_HEIGHT,
+      Math.floor(
+        (availableHeight - (frameCount - 1) * spacing) / Math.max(frameCount, 1)
+      )
+    )
+  );
+
+  var totalHeight = height * frameCount + spacing * (frameCount - 1);
+  if (totalHeight > availableHeight) {
+    spacing = Math.max(
+      UndirectedDFS.RECURSION_FRAME_MIN_SPACING,
+      Math.floor(
+        (availableHeight - height * frameCount) / Math.max(1, frameCount - 1)
+      )
+    );
+    if (spacing < 0) {
+      spacing = 0;
+    }
+    height = Math.max(
+      UndirectedDFS.RECURSION_FRAME_MIN_HEIGHT,
+      Math.floor(
+        (availableHeight - (frameCount - 1) * spacing) / Math.max(frameCount, 1)
+      )
+    );
+  }
+
+  layout.height = height;
+  layout.spacing = spacing;
+  layout.startY =
+    this.bottomSectionTopY +
+    UndirectedDFS.RECURSION_HEADER_HEIGHT +
+    UndirectedDFS.RECURSION_LABEL_MARGIN +
+    height / 2;
+
+  return layout;
+};
+
+UndirectedDFS.prototype.createRecursionArea = function () {
+  var frameCount = this.vertexLabels.length;
+  var layout = this.computeRecursionLayout(frameCount);
+  var framesTop = layout.startY - layout.height / 2;
+  var totalFrameHeight =
+    frameCount > 0
+      ? layout.height * frameCount + layout.spacing * (frameCount - 1)
+      : 0;
+  this.recursionBackgroundID = -1;
+
+  this.recursionHeaderID = this.nextIndex++;
+  this.cmd(
+    "CreateLabel",
+    this.recursionHeaderID,
+    "Call Stack",
+    UndirectedDFS.RECURSION_AREA_CENTER_X,
+    this.bottomSectionTopY + UndirectedDFS.RECURSION_HEADER_HEIGHT / 2,
+    0
+  );
+  this.cmd(
+    "SetForegroundColor",
+    this.recursionHeaderID,
+    UndirectedDFS.CODE_STANDARD_COLOR
+  );
+  this.cmd("SetTextStyle", this.recursionHeaderID, "bold 22");
+
+  this.recursionFrameIDs = [];
+  this.activeRecursionIndex = -1;
+  this.recursionDepth = 0;
+
+  var y = layout.startY;
+
+  for (var i = 0; i < frameCount; i++) {
+    var rectID = this.nextIndex++;
+    this.cmd(
+      "CreateRectangle",
+      rectID,
+      "",
+      UndirectedDFS.RECURSION_FRAME_WIDTH,
+      layout.height,
+      UndirectedDFS.RECURSION_AREA_CENTER_X,
+      y
+    );
+    this.cmd(
+      "SetBackgroundColor",
+      rectID,
+      UndirectedDFS.RECURSION_RECT_COLOR
+    );
+    this.cmd("SetForegroundColor", rectID, UndirectedDFS.RECURSION_RECT_BORDER);
+    this.cmd("SetAlpha", rectID, 0);
+    this.cmd("SetTextColor", rectID, UndirectedDFS.RECURSION_TEXT_COLOR);
+    this.cmd("SetTextStyle", rectID, UndirectedDFS.RECURSION_FONT);
+
+    this.recursionFrameIDs.push(rectID);
+
+    y += layout.height + layout.spacing;
+  }
+};
+
+UndirectedDFS.prototype.resetRecursionArea = function () {
+  this.recursionDepth = 0;
+  this.activeRecursionIndex = -1;
+  for (var i = 0; i < this.recursionFrameIDs.length; i++) {
+    this.cmd("SetAlpha", this.recursionFrameIDs[i], 0);
+    this.cmd("SetText", this.recursionFrameIDs[i], "");
+    this.cmd(
+      "SetForegroundColor",
+      this.recursionFrameIDs[i],
+      UndirectedDFS.RECURSION_RECT_BORDER
+    );
+  }
+};
+
+UndirectedDFS.prototype.pushRecursionFrame = function (vertex, parent) {
+  if (
+    this.recursionDepth < 0 ||
+    this.recursionDepth >= this.recursionFrameIDs.length ||
+    !this.vertexLabels ||
+    vertex < 0 ||
+    vertex >= this.vertexLabels.length
+  ) {
+    return;
+  }
+
+  if (this.activeRecursionIndex >= 0 && this.activeRecursionIndex < this.recursionFrameIDs.length) {
+    this.cmd(
+      "SetForegroundColor",
+      this.recursionFrameIDs[this.activeRecursionIndex],
+      UndirectedDFS.RECURSION_RECT_BORDER
+    );
+  }
+
+  var frameID = this.recursionFrameIDs[this.recursionDepth];
+  var text = "dfs(" + this.vertexLabels[vertex] + ")";
+  this.cmd("SetText", frameID, text);
+  this.cmd("SetAlpha", frameID, 1);
+  this.cmd("SetForegroundColor", frameID, UndirectedDFS.RECURSION_RECT_ACTIVE_BORDER);
+
+  this.activeRecursionIndex = this.recursionDepth;
+  this.recursionDepth++;
+};
+
+UndirectedDFS.prototype.popRecursionFrame = function () {
+  if (this.recursionDepth <= 0) {
+    return;
+  }
+
+  this.recursionDepth--;
+  var frameID = this.recursionFrameIDs[this.recursionDepth];
+  this.cmd("SetAlpha", frameID, 0);
+  this.cmd("SetText", frameID, "");
+  this.cmd("SetForegroundColor", frameID, UndirectedDFS.RECURSION_RECT_BORDER);
+
+  this.activeRecursionIndex = this.recursionDepth - 1;
+  if (this.activeRecursionIndex >= 0 && this.activeRecursionIndex < this.recursionFrameIDs.length) {
+    this.cmd(
+      "SetForegroundColor",
+      this.recursionFrameIDs[this.activeRecursionIndex],
+      UndirectedDFS.RECURSION_RECT_ACTIVE_BORDER
+    );
+  }
+};
+
+UndirectedDFS.prototype.highlightCodeLine = function (lineIndex) {
+  if (this.currentCodeLine >= 0) {
+    this.cmd(
+      "SetForegroundColor",
+      this.codeID[this.currentCodeLine][0],
+      UndirectedDFS.CODE_STANDARD_COLOR
+    );
+  }
+  this.currentCodeLine = lineIndex;
+  if (lineIndex >= 0) {
+    this.cmd(
+      "SetForegroundColor",
+      this.codeID[lineIndex][0],
+      UndirectedDFS.CODE_HIGHLIGHT_COLOR
+    );
+  }
+};
+
+UndirectedDFS.prototype.clearTraversalState = function () {
+  this.visited = new Array(this.vertexLabels.length);
+  this.parents = new Array(this.vertexLabels.length);
+  for (var i = 0; i < this.vertexLabels.length; i++) {
+    this.visited[i] = false;
+    this.parents[i] = null;
+    this.cmd("SetText", this.visitedRectIDs[i], "F");
+    this.cmd("SetBackgroundColor", this.visitedRectIDs[i], UndirectedDFS.ARRAY_RECT_COLOR);
+    this.cmd(
+      "SetForegroundColor",
+      this.visitedRectIDs[i],
+      UndirectedDFS.ARRAY_RECT_BORDER
+    );
+    this.cmd(
+      "SetRectangleLineThickness",
+      this.visitedRectIDs[i],
+      UndirectedDFS.ARRAY_RECT_BORDER_THICKNESS
+    );
+    this.cmd("SetText", this.parentRectIDs[i], "-");
+    this.cmd(
+      "SetBackgroundColor",
+      this.vertexIDs[i],
+      UndirectedDFS.GRAPH_NODE_COLOR
+    );
+    this.cmd(
+      "SetTextColor",
+      this.vertexIDs[i],
+      UndirectedDFS.GRAPH_NODE_TEXT
+    );
+  }
+  this.resetEdgesToUndirected();
+  this.resetRecursionArea();
+};
+
+UndirectedDFS.prototype.edgeKey = function (u, v) {
+  return u < v ? u + "-" + v : v + "-" + u;
+};
+
+UndirectedDFS.prototype.resetEdgesToUndirected = function () {
+  var key;
+  for (key in this.edgeOrientation) {
+    if (!this.edgeOrientation.hasOwnProperty(key)) {
+      continue;
+    }
+    var orientation = this.edgeOrientation[key];
+    this.cmd(
+      "Disconnect",
+      this.vertexIDs[orientation.from],
+      this.vertexIDs[orientation.to]
+    );
+  }
+
+  this.edgeOrientation = {};
+  for (var i = 0; i < this.edgePairs.length; i++) {
+    var edge = this.edgePairs[i];
+    var fromID = this.vertexIDs[edge.u];
+    var toID = this.vertexIDs[edge.v];
+    this.cmd(
+      "Connect",
+      fromID,
+      toID,
+      UndirectedDFS.EDGE_COLOR,
+      edge.curve,
+      0,
+      ""
+    );
+    this.cmd(
+      "SetEdgeThickness",
+      fromID,
+      toID,
+      UndirectedDFS.EDGE_THICKNESS
+    );
+    this.cmd("SetEdgeHighlight", fromID, toID, 0);
+    var edgeKey = this.edgeKey(edge.u, edge.v);
+    this.edgeOrientation[edgeKey] = { from: edge.u, to: edge.v };
+    this.edgeStates[edgeKey] = { tree: false };
+    this.edgeMeta[edgeKey] = edge;
+  }
+};
+
+UndirectedDFS.prototype.setEdgeState = function (u, v, options) {
+  var key = this.edgeKey(u, v);
+  var orientation = this.edgeOrientation[key];
+  if (!orientation) {
+    return;
+  }
+  var fromID = this.vertexIDs[orientation.from];
+  var toID = this.vertexIDs[orientation.to];
+  if (options.highlight !== undefined) {
+    this.cmd("SetEdgeHighlight", fromID, toID, options.highlight ? 1 : 0);
+  }
+  if (options.color) {
+    this.cmd("SetEdgeColor", fromID, toID, options.color);
+  }
+};
+
+UndirectedDFS.prototype.setEdgeActive = function (u, v, active) {
+  var key = this.edgeKey(u, v);
+  var orientation = this.edgeOrientation[key];
+  if (!orientation) {
+    return;
+  }
+  var fromID = this.vertexIDs[orientation.from];
+  var toID = this.vertexIDs[orientation.to];
+  var baseColor = UndirectedDFS.EDGE_COLOR;
+  if (this.edgeStates[key] && this.edgeStates[key].tree) {
+    baseColor = UndirectedDFS.EDGE_VISITED_COLOR;
+  }
+
+  if (active) {
+    this.setEdgeState(u, v, {
+      highlight: true,
+      color: baseColor
+    });
+    this.cmd(
+      "SetEdgeThickness",
+      fromID,
+      toID,
+      UndirectedDFS.EDGE_ACTIVE_THICKNESS
+    );
+  } else {
+    this.setEdgeState(u, v, { highlight: false, color: baseColor });
+    this.cmd(
+      "SetEdgeThickness",
+      fromID,
+      toID,
+      UndirectedDFS.EDGE_THICKNESS
+    );
+  }
+};
+
+UndirectedDFS.prototype.animateHighlightTraversal = function (fromIndex, toIndex) {
+  if (fromIndex === toIndex) {
+    return;
+  }
+
+  var startPos = this.vertexPositions[fromIndex];
+  var endPos = this.vertexPositions[toIndex];
+  var key = this.edgeKey(fromIndex, toIndex);
+  var meta = this.edgeMeta[key];
+  var curve = 0;
+  if (meta) {
+    curve = meta.curve;
+    if (curve !== 0 && fromIndex === meta.v && toIndex === meta.u) {
+      curve = -curve;
+    }
+  }
+
+  if (!meta || Math.abs(curve) < 0.01) {
+    this.cmd("Move", this.highlightCircleID, Math.round(endPos.x), Math.round(endPos.y));
+    this.cmd("Step");
+    return;
+  }
+
+  var dx = endPos.x - startPos.x;
+  var dy = endPos.y - startPos.y;
+  var midX = (startPos.x + endPos.x) / 2;
+  var midY = (startPos.y + endPos.y) / 2;
+  var controlX = midX - dy * curve;
+  var controlY = midY + dx * curve;
+
+  this.cmd(
+    "MoveAlongCurve",
+    this.highlightCircleID,
+    Math.round(controlX),
+    Math.round(controlY),
+    Math.round(endPos.x),
+    Math.round(endPos.y)
+  );
+  this.cmd("Step");
+};
+
+UndirectedDFS.prototype.markEdgeAsTreeEdge = function (parent, child) {
+  var key = this.edgeKey(parent, child);
+  var orientation = this.edgeOrientation[key];
+  var meta = this.edgeMeta[key];
+  if (!orientation || !meta) {
+    return;
+  }
+
+  this.cmd(
+    "Disconnect",
+    this.vertexIDs[orientation.from],
+    this.vertexIDs[orientation.to]
+  );
+  var curve = meta.curve;
+  if (curve !== 0 && parent === meta.v && child === meta.u) {
+    curve = -curve;
+  }
+
+  this.cmd(
+    "Connect",
+    this.vertexIDs[parent],
+    this.vertexIDs[child],
+    UndirectedDFS.EDGE_VISITED_COLOR,
+    curve,
+    1,
+    ""
+  );
+  this.cmd(
+    "SetEdgeThickness",
+    this.vertexIDs[parent],
+    this.vertexIDs[child],
+    UndirectedDFS.EDGE_TREE_THICKNESS
+  );
+  this.cmd(
+    "SetEdgeHighlight",
+    this.vertexIDs[parent],
+    this.vertexIDs[child],
+    1
+  );
+  this.edgeOrientation[key] = { from: parent, to: child };
+  this.edgeStates[key] = { tree: true };
+};
+
+UndirectedDFS.prototype.computeTemplateLayout = function (vertexCount) {
+  var layout = [];
+  var baseX = 180;
+  var stepX = 130;
+  var baseY = UndirectedDFS.ROW2_START_Y + 120;
+  var rowSpacing = 150;
+  var rowPattern = [4, 3, 4, 3, 4];
+
+  for (var row = 0, index = 0; row < rowPattern.length; row++) {
+    var count = rowPattern[row];
+    var startX = count === 4 ? baseX : baseX + stepX / 2;
+    var y = baseY + row * rowSpacing;
+    for (var col = 0; col < count && index < vertexCount; col++, index++) {
+      layout.push({ x: startX + col * stepX, y: y });
+    }
+    if (layout.length >= vertexCount) {
+      break;
+    }
+  }
+
+  return layout;
+};
+
+UndirectedDFS.prototype.generateRandomGraph = function (vertexCount) {
+  this.vertexPositions = this.computeTemplateLayout(vertexCount);
+
+  var allowed = UndirectedDFS.TEMPLATE_ALLOWED;
+  var curves = UndirectedDFS.TEMPLATE_CURVES;
+  var edges = [];
+  var existing = {};
+
+  var addEdge = function (u, v) {
+    if (u === v) {
+      return false;
+    }
+    var a = Math.min(u, v);
+    var b = Math.max(u, v);
+    var key = a + "-" + b;
+    if (existing[key]) {
+      return false;
+    }
+    var curve = 0;
+    if (
+      curves[a] &&
+      typeof curves[a][b] === "number" &&
+      Math.abs(curves[a][b]) > 0.0001
+    ) {
+      curve = curves[a][b];
+    }
+    edges.push({ u: a, v: b, curve: curve });
+    existing[key] = true;
+    return true;
+  };
+
+  for (var v = 1; v < vertexCount; v++) {
+    var neighbors = [];
+    for (var u = 0; u < vertexCount; u++) {
+      if (allowed[v] && allowed[v][u]) {
+        neighbors.push(u);
+      }
+    }
+    if (neighbors.length > 0) {
+      for (var t = neighbors.length - 1; t >= 0; t--) {
+        var swap = Math.floor(Math.random() * (t + 1));
+        var candidate = neighbors[swap];
+        neighbors[swap] = neighbors[t];
+        neighbors[t] = candidate;
+        if (addEdge(candidate, v)) {
+          break;
+        }
+      }
+    }
+  }
+
+  var edgePercent = 0.45;
+  for (var i = 0; i < vertexCount; i++) {
+    for (var j = i + 1; j < vertexCount; j++) {
+      if (!allowed[i] || !allowed[i][j]) {
+        continue;
+      }
+      if (existing[i + "-" + j]) {
+        continue;
+      }
+      if (Math.random() <= edgePercent) {
+        addEdge(i, j);
+      }
+    }
+  }
+
+  var hasCurve = false;
+  for (var e = 0; e < edges.length; e++) {
+    if (Math.abs(edges[e].curve) > 0.01) {
+      hasCurve = true;
+      break;
+    }
+  }
+  if (!hasCurve) {
+    for (var r = 0; r < vertexCount && !hasCurve; r++) {
+      for (var c = r + 1; c < vertexCount && !hasCurve; c++) {
+        if (!allowed[r] || !allowed[r][c]) {
+          continue;
+        }
+        if (
+          curves[r] &&
+          typeof curves[r][c] === "number" &&
+          Math.abs(curves[r][c]) > 0.01
+        ) {
+          if (addEdge(r, c)) {
+            hasCurve = true;
+          }
+        }
+      }
+    }
+  }
+
+  this.edgePairs = edges;
+};
+
+UndirectedDFS.prototype.applyVertexClamping = function (
+  minX,
+  maxX,
+  minY,
+  maxY
+) {
+  for (var i = 0; i < this.vertexPositions.length; i++) {
+    this.vertexPositions[i].x = Math.max(
+      minX,
+      Math.min(maxX, this.vertexPositions[i].x)
+    );
+    this.vertexPositions[i].y = Math.max(
+      minY,
+      Math.min(maxY, this.vertexPositions[i].y)
+    );
+  }
+};
+
+UndirectedDFS.prototype.relaxVertices = function (
+  minSeparation,
+  iterations,
+  minX,
+  maxX,
+  minY,
+  maxY
+) {
+  iterations = Math.max(0, iterations);
+  for (var iteration = 0; iteration < iterations; iteration++) {
+    for (var a = 0; a < this.vertexPositions.length; a++) {
+      for (var b = a + 1; b < this.vertexPositions.length; b++) {
+        var dx = this.vertexPositions[b].x - this.vertexPositions[a].x;
+        var dy = this.vertexPositions[b].y - this.vertexPositions[a].y;
+        var dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist === 0) {
+          dx = (Math.random() - 0.5) * 0.01;
+          dy = (Math.random() - 0.5) * 0.01;
+          dist = Math.sqrt(dx * dx + dy * dy);
+        }
+        if (dist < minSeparation) {
+          var push = (minSeparation - dist) / 2;
+          var nx = dx / dist;
+          var ny = dy / dist;
+          this.vertexPositions[a].x -= nx * push;
+          this.vertexPositions[a].y -= ny * push;
+          this.vertexPositions[b].x += nx * push;
+          this.vertexPositions[b].y += ny * push;
+        }
+      }
+    }
+    this.applyVertexClamping(minX, maxX, minY, maxY);
+  }
+};
+
+UndirectedDFS.prototype.roundVertexPositions = function () {
+  for (var i = 0; i < this.vertexPositions.length; i++) {
+    this.vertexPositions[i].x = Math.round(this.vertexPositions[i].x);
+    this.vertexPositions[i].y = Math.round(this.vertexPositions[i].y);
+  }
+};
+
+UndirectedDFS.prototype.pushVerticesAwayFromEdges = function (
+  edges,
+  clearance,
+  iterations,
+  minX,
+  maxX,
+  minY,
+  maxY
+) {
+  if (!edges || edges.length === 0) {
+    return;
+  }
+  var vertexCount = this.vertexPositions.length;
+  var influence = clearance * 0.45;
+  for (var iter = 0; iter < iterations; iter++) {
+    var adjustments = new Array(vertexCount);
+    for (var i = 0; i < vertexCount; i++) {
+      adjustments[i] = { x: 0, y: 0 };
+    }
+    var changed = false;
+
+    for (var e = 0; e < edges.length; e++) {
+      var u = edges[e].u;
+      var v = edges[e].v;
+      var start = this.vertexPositions[u];
+      var end = this.vertexPositions[v];
+      var edgeDX = end.x - start.x;
+      var edgeDY = end.y - start.y;
+      var edgeLenSq = edgeDX * edgeDX + edgeDY * edgeDY;
+      if (edgeLenSq === 0) {
+        continue;
+      }
+
+      for (var w = 0; w < vertexCount; w++) {
+        if (w === u || w === v) {
+          continue;
+        }
+        var point = this.vertexPositions[w];
+        var t =
+          ((point.x - start.x) * edgeDX + (point.y - start.y) * edgeDY) /
+          edgeLenSq;
+        t = Math.max(0, Math.min(1, t));
+        var closestX = start.x + t * edgeDX;
+        var closestY = start.y + t * edgeDY;
+        var diffX = point.x - closestX;
+        var diffY = point.y - closestY;
+        var dist = Math.sqrt(diffX * diffX + diffY * diffY);
+        if (dist < clearance) {
+          var away = Math.max(dist, 0.0001);
+          var strength = (clearance - dist) / clearance;
+          adjustments[w].x += (diffX / away) * strength * influence;
+          adjustments[w].y += (diffY / away) * strength * influence;
+          changed = true;
+        }
+      }
+    }
+
+    if (!changed) {
+      break;
+    }
+
+    for (var idx = 0; idx < vertexCount; idx++) {
+      this.vertexPositions[idx].x += adjustments[idx].x;
+      this.vertexPositions[idx].y += adjustments[idx].y;
+    }
+
+    this.applyVertexClamping(minX, maxX, minY, maxY);
+  }
+};
+
+UndirectedDFS.prototype.cleanInputLabel = function (value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.replace(/^\s+/, "").replace(/\s+$/, "");
+};
+
+UndirectedDFS.prototype.findVertexIndex = function (label) {
+  if (!this.vertexLabels) {
+    return -1;
+  }
+  for (var i = 0; i < this.vertexLabels.length; i++) {
+    if (this.vertexLabels[i] === label) {
+      return i;
+    }
+  }
+  return -1;
+};
+
+UndirectedDFS.prototype.startCallback = function () {
+  if (!this.startField) return;
+  var raw = this.cleanInputLabel(this.startField.value);
+  if (raw.length === 0) return;
+  var label = raw[0].toUpperCase();
+  var index = this.findVertexIndex(label);
+  if (index === -1) {
+    return;
+  }
+  this.startField.value = label;
+  this.implementAction(this.runTraversal.bind(this), index);
+};
+
+UndirectedDFS.prototype.runTraversal = function (startIndex) {
+  this.commands = [];
+
+  this.clearTraversalState();
+
+  var startLabel = this.vertexLabels[startIndex];
+  this.cmd(
+    "SetText",
+    this.startDisplayID,
+    "Start Vertex: " + startLabel
+  );
+
+  var startPos = this.vertexPositions[startIndex];
+  this.cmd("SetAlpha", this.highlightCircleID, 1);
+  this.cmd("Move", this.highlightCircleID, startPos.x, startPos.y);
+  this.cmd("Step");
+
+  this.dfsVisit(startIndex, -1);
+
+  this.highlightCodeLine(-1);
+  this.cmd("SetAlpha", this.highlightCircleID, 0);
+
+  return this.commands;
+};
+
+UndirectedDFS.prototype.dfsVisit = function (u, parent) {
+  this.pushRecursionFrame(u, parent);
+  this.cmd("Step");
+
+  this.highlightCodeLine(0);
+  this.cmd("Step");
+
+  this.highlightCodeLine(1);
+  this.setVisitedCellHighlight(u, true);
+  this.cmd("Step");
+  if (!this.visited[u]) {
+    this.visited[u] = true;
+    this.cmd("SetText", this.visitedRectIDs[u], "T");
+    this.cmd(
+      "SetBackgroundColor",
+      this.visitedRectIDs[u],
+      UndirectedDFS.ARRAY_VISITED_FILL
+    );
+    this.cmd(
+      "SetBackgroundColor",
+      this.vertexIDs[u],
+      UndirectedDFS.GRAPH_NODE_VISITED_COLOR
+    );
+    this.cmd(
+      "SetTextColor",
+      this.vertexIDs[u],
+      UndirectedDFS.GRAPH_NODE_VISITED_TEXT_COLOR
+    );
+    this.cmd("Step");
+  }
+  this.setVisitedCellHighlight(u, false);
+
+  this.highlightCodeLine(2);
+  this.cmd("Step");
+
+  var neighbors = this.adjacencyList[u];
+  for (var i = 0; i < neighbors.length; i++) {
+    var v = neighbors[i];
+    if (v === parent) {
+      continue;
+    }
+    this.highlightCodeLine(3);
+    this.setEdgeActive(u, v, true);
+    this.cmd("Step");
+
+    this.setVisitedCellHighlight(v, true);
+    this.cmd("Step");
+
+    if (!this.visited[v]) {
+      this.highlightCodeLine(4);
+      this.parents[v] = u;
+      this.cmd(
+        "SetText",
+        this.parentRectIDs[v],
+        this.vertexLabels[u]
+      );
+      this.cmd("Step");
+
+      this.highlightCodeLine(5);
+      this.markEdgeAsTreeEdge(u, v);
+      this.cmd("Step");
+      this.animateHighlightTraversal(u, v);
+
+      this.dfsVisit(v, u);
+
+      this.animateHighlightTraversal(v, u);
+    }
+
+    this.setVisitedCellHighlight(v, false);
+
+    this.highlightCodeLine(6);
+    this.cmd("Step");
+
+    this.setEdgeActive(u, v, false);
+
+    this.highlightCodeLine(2);
+    this.cmd("Step");
+  }
+
+  this.highlightCodeLine(7);
+  this.cmd("Step");
+  this.highlightCodeLine(8);
+  this.cmd("Step");
+  this.popRecursionFrame();
+};
+
+UndirectedDFS.prototype.disableUI = function () {
+  for (var i = 0; i < this.controls.length; i++) {
+    this.controls[i].disabled = true;
+  }
+};
+
+UndirectedDFS.prototype.enableUI = function () {
+  for (var i = 0; i < this.controls.length; i++) {
+    this.controls[i].disabled = false;
+  }
+};
+
+var currentAlg;
+
+function init() {
+  var animManag = initCanvas();
+  currentAlg = new UndirectedDFS(animManag, canvas.width, canvas.height);
+}


### PR DESCRIPTION
## Summary
- add a defensive vertex lookup helper so Directed DFS no longer relies on Array.indexOf when resolving the starting vertex
- reuse the same lookup helper in Undirected DFS to keep both visualizations compatible with older browsers

## Testing
- node --check graphAlgorithms/DirectedDFS.js
- node --check graphAlgorithms/UndirectedDFS.js

------
https://chatgpt.com/codex/tasks/task_e_68dd94dd2878832ca4554e258b20c625