### PR TITLE
Adjust DFS call stack labels and highlight styling

### DIFF
--- a/graphAlgorithms/UndirectedDFS.js
+++ b/graphAlgorithms/UndirectedDFS.js
@@ -35,7 +35,7 @@ UndirectedDFS.HIGHLIGHT_RADIUS = UndirectedDFS.GRAPH_NODE_RADIUS;
 UndirectedDFS.EDGE_COLOR = "#4a4e69";
 UndirectedDFS.EDGE_VISITED_COLOR = "#66bb6a";
 UndirectedDFS.EDGE_THICKNESS = 3;
-UndirectedDFS.EDGE_ACTIVE_THICKNESS = UndirectedDFS.EDGE_THICKNESS;
+UndirectedDFS.EDGE_ACTIVE_THICKNESS = 2;
 UndirectedDFS.EDGE_TREE_THICKNESS = 6;
 
 UndirectedDFS.ARRAY_BASE_X = 720;
@@ -86,7 +86,7 @@ UndirectedDFS.CODE_LINES = [
   ["    visited[u] = true;"],
   ["    for (int v : adj[u]) {"],
   ["        if (v != parent && !visited[v]) {"],
-  ["            parent[v] = u;"],
+  ["            parentArr[v] = u;"],
   ["            dfs(v, u);"],
   ["        }"],
   ["    }"],
@@ -629,7 +629,17 @@ UndirectedDFS.prototype.pushRecursionFrame = function (vertex, parent) {
   }
 
   var frameID = this.recursionFrameIDs[this.recursionDepth];
-  var text = "dfs(" + this.vertexLabels[vertex] + ")";
+  var parentText = "null";
+  if (
+    parent !== undefined &&
+    parent !== null &&
+    parent >= 0 &&
+    parent < this.vertexLabels.length
+  ) {
+    parentText = this.vertexLabels[parent];
+  }
+  var text =
+    "dfs(" + this.vertexLabels[vertex] + ", " + parentText + ")";
   this.cmd("SetText", frameID, text);
   this.cmd("SetAlpha", frameID, 1);
   this.cmd("SetForegroundColor", frameID, UndirectedDFS.RECURSION_RECT_ACTIVE_BORDER);


### PR DESCRIPTION
## Summary
- show parent arguments in the recursion stack and label the initial call as dfs(A,null)
- rename the displayed Java parent array reference to parentArr to avoid confusion
- thin the highlighted DFS edges for better visual consistency

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df6405d308832cba0f7f615611b567